### PR TITLE
Add sequential scheduling for montaje

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ El trabajador **Unai** solo recibe tareas si se le asignan manualmente en la
 lista de proyectos. El planificador automático lo ignora al repartir
 fases por defecto.
 
+Al planificar el montaje se respeta el orden en que cada trabajador termina
+su proyecto anterior. Un nuevo montaje se coloca justo después del último día
+que tenga programado ese trabajador, salvo que la prioridad del nuevo proyecto
+sea mayor y deba adelantarse en la cola.
+
 La fase **Pedidos**, realizada por Irene, se indica ahora mediante el campo
 **Plazo acopio**. Esta fase abarca desde que termina el dibujo hasta la fecha
 de acopio indicada y no se reparte por horas. Irene puede acumular tantos


### PR DESCRIPTION
## Summary
- queue montaje tasks so each worker finishes a project before starting a new one
- document sequential montaje planning rule

## Testing
- `python -m py_compile schedule.py`


------
https://chatgpt.com/codex/tasks/task_e_686b7f93928083258e3701d841987fef