### PR TITLE
Allow manual placement and show worker skills

### DIFF
--- a/templates/complete.html
+++ b/templates/complete.html
@@ -137,7 +137,7 @@
     <tbody>
 {% for worker, days_data in schedule.items() %}
     <tr data-worker="{{ worker }}">
-        <td class="resource-col"><span class="worker-toggle">&#8722;</span>{{ worker }} ({{ workers[worker]|join(', ') }})</td>
+        <td class="resource-col"><span class="worker-toggle">&#8722;</span><strong>{{ worker.upper() }}</strong> ({{ workers[worker]|join(', ') }})</td>
         {% for c in cols %}
         {% if c.type == 'day' %}
         {% set d = c.dates[0] %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -61,7 +61,7 @@
     <tbody>
 {% for worker, days_data in schedule.items() %}
     <tr data-worker="{{ worker }}">
-        <td class="resource-col"><span class="worker-toggle">&#8722;</span>{{ worker }} ({{ workers[worker]|join(', ') }})</td>
+        <td class="resource-col"><span class="worker-toggle">&#8722;</span><strong>{{ worker.upper() }}</strong> ({{ workers[worker]|join(', ') }})</td>
         {% for c in cols %}
         {% if c.type == 'day' %}
         {% set d = c.dates[0] %}

--- a/templates/vacations.html
+++ b/templates/vacations.html
@@ -17,7 +17,7 @@
     <tr><th>Trabajador</th><th>Inicio</th><th>Fin</th><th></th></tr>
     {% for v in vacations %}
     <tr>
-        <td>{{ v.worker }}</td>
+        <td><strong>{{ v.worker.upper() }}</strong></td>
         <td>{{ v.start }}</td>
         <td>{{ v.end }}</td>
         <td>


### PR DESCRIPTION
## Summary
- permit manual phase placement regardless of mounting queue
- show each worker's skills and highlight their names in uppercase

## Testing
- `python -m py_compile app.py schedule.py`

------
https://chatgpt.com/codex/tasks/task_e_68776a7165fc8325845adc1c3a0ec14f