### PR TITLE
Persist project filters and improve schedule scrolling

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -85,7 +85,10 @@ table.schedule td.weekend-cell {
 .controls { display: flex; gap: 10px; align-items: center; margin-bottom: 5px; }
 
 .calendar-flex { display: flex; align-items: flex-start; position: relative; width: 100%; }
+.schedule-container { display: flex; flex-direction: column; flex: 1; }
 .schedule-wrapper { flex: 1; overflow-x: auto; }
+.schedule-scroll-top { overflow-x: auto; overflow-y: hidden; }
+.schedule-scroll-top div { height: 1px; }
 .unplanned-panel {
     width: 2500px;
     border-left: 1px solid #ccc;

--- a/templates/complete.html
+++ b/templates/complete.html
@@ -72,6 +72,8 @@
             <button id="today-btn">HOY</button>
         </div>
         <div class="calendar-flex">
+        <div class="schedule-container">
+        <div class="schedule-scroll-top"><div></div></div>
         <div class="schedule-wrapper">
 <table class="schedule">
     <thead>
@@ -169,6 +171,7 @@
     </tr>
     </tfoot>
         </table>
+        </div>
         </div>
         <div class="unplanned-panel" id="unplanned-panel">
             <div id="unplanned-resizer" class="unplanned-resizer"></div>
@@ -420,6 +423,32 @@
     </div>
 </div>
 <script>
+  const FILTER_KEY = 'projectsFilter';
+  (function() {
+    const form = document.querySelector('.complete-projects form.controls');
+    if (!form) return;
+    const projInput = form.querySelector('input[name="project"]');
+    const clientInput = form.querySelector('input[name="client"]');
+    const sortSelect = form.querySelector('select[name="sort"]');
+    const saved = JSON.parse(localStorage.getItem(FILTER_KEY) || '{}');
+    if (!location.search && (saved.project || saved.client || saved.sort)) {
+      const params = new URLSearchParams(saved);
+      location.search = params.toString();
+      return;
+    }
+    localStorage.setItem(FILTER_KEY, JSON.stringify({
+      project: projInput.value,
+      client: clientInput.value,
+      sort: sortSelect.value
+    }));
+    form.addEventListener('submit', () => {
+      localStorage.setItem(FILTER_KEY, JSON.stringify({
+        project: projInput.value,
+        client: clientInput.value,
+        sort: sortSelect.value
+      }));
+    });
+  })();
   const PROJECT_DATA = {{ project_data|tojson }};
   console.log(PROJECT_DATA);
   const PHASES = {{ phases|tojson }};
@@ -471,10 +500,21 @@
 
 
   const wrapper = document.querySelector('.schedule-wrapper');
+  const topScroll = document.querySelector('.schedule-scroll-top');
+  let syncTopWidth;
+  if (topScroll) {
+    const topInner = topScroll.firstElementChild;
+    syncTopWidth = () => { topInner.style.width = wrapper.scrollWidth + 'px'; };
+    syncTopWidth();
+    window.addEventListener('resize', syncTopWidth);
+    topScroll.addEventListener('scroll', () => { wrapper.scrollLeft = topScroll.scrollLeft; });
+    wrapper.addEventListener('scroll', () => { topScroll.scrollLeft = wrapper.scrollLeft; });
+  }
   const SCROLL_KEY = 'calendarScroll';
   const savedScroll = sessionStorage.getItem(SCROLL_KEY);
   if (savedScroll !== null) {
     wrapper.scrollLeft = parseFloat(savedScroll);
+    if (topScroll) topScroll.scrollLeft = wrapper.scrollLeft;
   } else {
     const todayCell = document.querySelector('th.today');
     if (todayCell) todayCell.scrollIntoView({behavior: 'auto', inline: 'center'});
@@ -933,62 +973,82 @@
       });
     });
   });
-  const unplanPanel = document.getElementById('unplanned-panel');
-  const unplanHide = document.getElementById('unplanned-hide');
-  const unplanShow = document.getElementById('unplanned-show');
-  const unplanResizer = document.getElementById('unplanned-resizer');
-  const UNPLAN_WIDTH_KEY = 'unplannedWidth';
+    const unplanPanel = document.getElementById('unplanned-panel');
+    const unplanHide = document.getElementById('unplanned-hide');
+    const unplanShow = document.getElementById('unplanned-show');
+    const unplanResizer = document.getElementById('unplanned-resizer');
+    const UNPLAN_WIDTH_KEY = 'unplannedWidth';
+    const UNPLAN_SCROLL_KEY = 'unplannedScroll';
+    const unplanList = unplanPanel ? unplanPanel.querySelector('.unplanned-list') : null;
 
-  function syncUnplannedHeight() {
-    const wrap = document.querySelector('.schedule-wrapper');
-    if (wrap && unplanPanel) {
-      unplanPanel.style.height = wrap.offsetHeight + 'px';
+    function syncUnplannedHeight() {
+      const container = document.querySelector('.schedule-container');
+      if (container && unplanPanel) {
+        unplanPanel.style.height = container.offsetHeight + 'px';
+      }
     }
-  }
 
   syncUnplannedHeight();
   window.addEventListener('resize', syncUnplannedHeight);
-  if (unplanPanel) {
-    const savedWidth = localStorage.getItem(UNPLAN_WIDTH_KEY);
-    if (savedWidth) {
-      unplanPanel.style.width = savedWidth + 'px';
-    }
-  }
-  if (unplanPanel && unplanHide && unplanShow) {
-    unplanHide.addEventListener('click', () => {
-      localStorage.setItem(UNPLAN_WIDTH_KEY, unplanPanel.offsetWidth);
-      unplanPanel.style.display = 'none';
-      unplanShow.style.display = 'block';
-    });
-    unplanShow.addEventListener('click', () => {
-      const saved = localStorage.getItem(UNPLAN_WIDTH_KEY);
-      if (saved) {
-        unplanPanel.style.width = saved + 'px';
+    if (unplanPanel) {
+      const savedWidth = localStorage.getItem(UNPLAN_WIDTH_KEY);
+      if (savedWidth) {
+        unplanPanel.style.width = savedWidth + 'px';
       }
-      unplanPanel.style.display = 'block';
-      unplanShow.style.display = 'none';
-      syncUnplannedHeight();
-    });
-  }
-  if (unplanPanel && unplanResizer) {
-    let startX, startWidth;
-    const onMouseMove = (e) => {
-      const dx = startX - e.clientX;
-      const newWidth = Math.max(100, startWidth + dx);
-      unplanPanel.style.width = newWidth + 'px';
-    };
-    const onMouseUp = () => {
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup', onMouseUp);
-      localStorage.setItem(UNPLAN_WIDTH_KEY, unplanPanel.offsetWidth);
-    };
-    unplanResizer.addEventListener('mousedown', (e) => {
-      startX = e.clientX;
-      startWidth = unplanPanel.offsetWidth;
-      document.addEventListener('mousemove', onMouseMove);
-      document.addEventListener('mouseup', onMouseUp);
-    });
-  }
+      if (unplanList) {
+        const savedScroll = localStorage.getItem(UNPLAN_SCROLL_KEY);
+        if (savedScroll) unplanList.scrollTop = parseInt(savedScroll, 10);
+        unplanList.addEventListener('scroll', () => {
+          localStorage.setItem(UNPLAN_SCROLL_KEY, unplanList.scrollTop);
+        });
+      }
+    }
+  if (unplanPanel && unplanHide && unplanShow) {
+      unplanHide.addEventListener('click', () => {
+        localStorage.setItem(UNPLAN_WIDTH_KEY, unplanPanel.offsetWidth);
+        if (unplanList) localStorage.setItem(UNPLAN_SCROLL_KEY, unplanList.scrollTop);
+        unplanPanel.style.display = 'none';
+        unplanShow.style.display = 'block';
+        if (syncTopWidth) syncTopWidth();
+        if (topScroll) topScroll.scrollLeft = wrapper.scrollLeft;
+      });
+      unplanShow.addEventListener('click', () => {
+        const saved = localStorage.getItem(UNPLAN_WIDTH_KEY);
+        if (saved) {
+          unplanPanel.style.width = saved + 'px';
+        }
+        unplanPanel.style.display = 'block';
+        unplanShow.style.display = 'none';
+        syncUnplannedHeight();
+        if (syncTopWidth) syncTopWidth();
+        if (topScroll) topScroll.scrollLeft = wrapper.scrollLeft;
+        if (unplanList) {
+          const s = localStorage.getItem(UNPLAN_SCROLL_KEY);
+          if (s) unplanList.scrollTop = parseInt(s, 10);
+        }
+      });
+    }
+    if (unplanPanel && unplanResizer) {
+      let startX, startWidth;
+      const onMouseMove = (e) => {
+        const dx = startX - e.clientX;
+        const newWidth = Math.max(100, startWidth + dx);
+        unplanPanel.style.width = newWidth + 'px';
+      };
+      const onMouseUp = () => {
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', onMouseUp);
+        localStorage.setItem(UNPLAN_WIDTH_KEY, unplanPanel.offsetWidth);
+        if (syncTopWidth) syncTopWidth();
+        if (topScroll) topScroll.scrollLeft = wrapper.scrollLeft;
+      };
+      unplanResizer.addEventListener('mousedown', (e) => {
+        startX = e.clientX;
+        startWidth = unplanPanel.offsetWidth;
+        document.addEventListener('mousemove', onMouseMove);
+        document.addEventListener('mouseup', onMouseUp);
+      });
+    }
   document.querySelectorAll('.task.vacation').forEach(div => {
     div.addEventListener('click', () => {
       const del = div.querySelector('.vac-delete');

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,9 @@
 <div class="hours-btn-container">
     <button id="hours-btn" type="button">Editar jornada laboral</button>
 </div>
-<div class="schedule-wrapper">
+<div class="schedule-container">
+    <div class="schedule-scroll-top"><div></div></div>
+    <div class="schedule-wrapper">
 <table class="schedule">
     <thead>
     {% set day_names = ['Lun','Mar','Mié','Jue','Vie','Sáb','Dom'] %}
@@ -109,6 +111,7 @@
     </tr>
     </tfoot>
 </table>
+    </div>
 </div>
 <div id="info-popup" class="info-popup"></div>
 <div id="conflict-modal" class="conflict-modal"><div class="conflict-content"><div id="conflict-text"></div><button id="conflict-close">Cerrar</button></div></div>
@@ -167,10 +170,21 @@
 
   // allow horizontal scrolling with Shift + wheel over the schedule
   const wrapper = document.querySelector('.schedule-wrapper');
+  const topScroll = document.querySelector('.schedule-scroll-top');
+  let syncTopWidth;
+  if (topScroll) {
+    const topInner = topScroll.firstElementChild;
+    syncTopWidth = () => { topInner.style.width = wrapper.scrollWidth + 'px'; };
+    syncTopWidth();
+    window.addEventListener('resize', syncTopWidth);
+    topScroll.addEventListener('scroll', () => { wrapper.scrollLeft = topScroll.scrollLeft; });
+    wrapper.addEventListener('scroll', () => { topScroll.scrollLeft = wrapper.scrollLeft; });
+  }
   const SCROLL_KEY = 'calendarScroll';
   const savedScroll = sessionStorage.getItem(SCROLL_KEY);
   if (savedScroll !== null) {
     wrapper.scrollLeft = parseFloat(savedScroll);
+    if (topScroll) topScroll.scrollLeft = wrapper.scrollLeft;
   } else {
     const todayCell = document.querySelector('th.today');
     if (todayCell) todayCell.scrollIntoView({behavior: 'auto', inline: 'center'});

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -158,6 +158,32 @@
     </tbody>
 </table>
 <script>
+  const FILTER_KEY = 'projectsFilter';
+  (function() {
+    const form = document.querySelector('form.controls');
+    if (!form) return;
+    const projInput = form.querySelector('input[name="project"]');
+    const clientInput = form.querySelector('input[name="client"]');
+    const sortSelect = form.querySelector('select[name="sort"]');
+    const saved = JSON.parse(localStorage.getItem(FILTER_KEY) || '{}');
+    if (!location.search && (saved.project || saved.client || saved.sort)) {
+      const params = new URLSearchParams(saved);
+      location.search = params.toString();
+      return;
+    }
+    localStorage.setItem(FILTER_KEY, JSON.stringify({
+      project: projInput.value,
+      client: clientInput.value,
+      sort: sortSelect.value
+    }));
+    form.addEventListener('submit', () => {
+      localStorage.setItem(FILTER_KEY, JSON.stringify({
+        project: projInput.value,
+        client: clientInput.value,
+        sort: sortSelect.value
+      }));
+    });
+  })();
   const START_URL = "{{ url_for('update_phase_start') }}";
   const DUE_URL = "{{ url_for('update_due_date') }}";
   const PROJ_START_URL = "{{ url_for('update_start_date') }}";


### PR DESCRIPTION
## Summary
- remember project list filters across sessions using localStorage
- keep unplanned phases column size and scroll position when toggled
- add synced top horizontal scrollbar to calendar views

## Testing
- `python -m py_compile app.py schedule.py`


------
https://chatgpt.com/codex/tasks/task_e_689497ce2fbc8325a594578eefc5b5e2