### PR TITLE
Unify calendar views and preserve schedules when deleting projects

### DIFF
--- a/schedule.py
+++ b/schedule.py
@@ -11,6 +11,7 @@ MILESTONES_FILE = os.path.join(DATA_DIR, 'milestones.json')
 VACATIONS_FILE = os.path.join(DATA_DIR, 'vacations.json')
 DAILY_HOURS_FILE = os.path.join(DATA_DIR, 'daily_hours.json')
 INACTIVE_WORKERS_FILE = os.path.join(DATA_DIR, 'inactive_workers.json')
+EXTRA_WORKERS_FILE = os.path.join(DATA_DIR, 'extra_workers.json')
 
 PHASE_ORDER = [
     'dibujo',
@@ -24,7 +25,9 @@ PHASE_ORDER = [
 ]
 PRIORITY_ORDER = {'Alta': 1, 'Media': 2, 'Baja': 3, 'Sin prioridad': 4}
 
-WORKERS = {
+UNPLANNED = 'Sin planificar'
+
+BASE_WORKERS = {
     'Pilar': ['dibujo'],
     'Joseba 1': ['dibujo'],
     'Irene': ['pedidos'],
@@ -38,14 +41,42 @@ WORKERS = {
     'Igor': ['soldar'],
     'Albi': ['recepcionar material', 'soldar', 'montar'],
     'Eneko': ['pintar', 'montar', 'soldar'],
+}
+
+TAIL_WORKERS = {
     'Mecanizar': ['mecanizar'],
     'Tratamiento': ['tratamiento'],
-    'Sin planificar': PHASE_ORDER,
+    UNPLANNED: PHASE_ORDER,
 }
+
+
+def load_extra_workers():
+    if os.path.exists(EXTRA_WORKERS_FILE):
+        with open(EXTRA_WORKERS_FILE, 'r') as f:
+            return json.load(f)
+    return []
+
+
+def save_extra_workers(workers):
+    os.makedirs(DATA_DIR, exist_ok=True)
+    with open(EXTRA_WORKERS_FILE, 'w') as f:
+        json.dump(workers, f)
+
+
+def _build_workers(extra=None):
+    workers = BASE_WORKERS.copy()
+    if extra is None:
+        extra = load_extra_workers()
+    for w in extra:
+        workers[w] = BASE_WORKERS['Eneko'][:]
+    workers.update(TAIL_WORKERS)
+    return workers
+
+
+WORKERS = _build_workers()
 
 # Igor deja de aparecer en el calendario a partir del 21 de julio
 IGOR_END = date(2025, 7, 21)
-UNPLANNED = 'Sin planificar'
 
 HOURS_PER_DAY = 8
 HOURS_LIMITS = {w: HOURS_PER_DAY for w in WORKERS}
@@ -54,6 +85,21 @@ HOURS_LIMITS['Mecanizar'] = float('inf')
 HOURS_LIMITS['Tratamiento'] = float('inf')
 HOURS_LIMITS[UNPLANNED] = float('inf')
 WEEKEND = {5, 6}  # Saturday=5, Sunday=6 in weekday()
+
+
+def add_worker(name):
+    """Add a new worker that behaves like Eneko."""
+    name = name.strip()
+    if not name or name in WORKERS:
+        return
+    extras = load_extra_workers()
+    if name not in extras:
+        extras.append(name)
+        save_extra_workers(extras)
+    new_workers = _build_workers(extras)
+    WORKERS.clear()
+    WORKERS.update(new_workers)
+    HOURS_LIMITS[name] = HOURS_PER_DAY
 
 
 def load_projects():
@@ -207,16 +253,15 @@ def schedule_projects(projects):
                     'priority': '',
                     'pid': f"vac-{worker}-{day.isoformat()}"
                 })
-    # Place frozen projects first so other tasks respect their positions
+    # Place frozen phases first so other tasks respect their positions
     for p in projects:
-        if p.get('frozen'):
-            for t in p.get('frozen_tasks', []):
-                w = t['worker']
-                day = t['day']
-                entry = t.copy()
-                entry.pop('worker', None)
-                entry.pop('day', None)
-                worker_schedule.setdefault(w, {}).setdefault(day, []).append(entry)
+        for t in p.get('frozen_tasks', []):
+            w = t['worker']
+            day = t['day']
+            entry = t.copy()
+            entry.pop('worker', None)
+            entry.pop('day', None)
+            worker_schedule.setdefault(w, {}).setdefault(day, []).append(entry)
 
     # Sort frozen tasks chronologically
     for w, days in worker_schedule.items():
@@ -225,8 +270,6 @@ def schedule_projects(projects):
 
     conflicts = []
     for project in projects:
-        if project.get('frozen'):
-            continue
         planned = project.get('planned', True)
         if not planned:
             current = date.today()
@@ -238,14 +281,33 @@ def schedule_projects(projects):
                 current = date.today()
                 project['start_date'] = current.isoformat()
         hour = 0
+        frozen_end = {}
+        for t in project.get('frozen_tasks', []):
+            ph = t.get('phase')
+            try:
+                d = date.fromisoformat(t['day'])
+            except Exception:
+                continue
+            if ph in PHASE_ORDER:
+                prev = frozen_end.get(ph)
+                if not prev or d > prev:
+                    frozen_end[ph] = d
         end_date = current
         assigned = project.get('assigned', {})
         for phase in PHASE_ORDER:
             val = project['phases'].get(phase)
             if not val:
                 continue
+            if phase in frozen_end:
+                current = next_workday(frozen_end[phase])
+                end_date = max(end_date, frozen_end[phase])
+                hour = 0
+                continue
 
             if phase == 'pedidos' and isinstance(val, str) and '-' in val:
+                start_overrides = project.get('segment_starts', {}).get(phase)
+                if start_overrides and start_overrides[0]:
+                    current = date.fromisoformat(start_overrides[0])
                 days_needed = sum(
                     1
                     for i in range((date.fromisoformat(val) - current).days + 1)
@@ -286,7 +348,6 @@ def schedule_projects(projects):
                     project.get('priority'),
                     project['id'],
                     worker,
-                    project_frozen=project.get('frozen', False),
                     project_blocked=project.get('blocked', False),
                     material_date=project.get('material_confirmed_date'),
                 )
@@ -336,9 +397,8 @@ def schedule_projects(projects):
                     manual = False
                     if start_overrides and idx < len(start_overrides) and start_overrides[idx]:
                         override = date.fromisoformat(start_overrides[idx])
-                        if override > current:
-                            current = override
-                            hour = 0
+                        current = override
+                        hour = 0
                         manual = True
                     current, hour, end_date = assign_phase(
                         worker_schedule[worker],
@@ -357,7 +417,6 @@ def schedule_projects(projects):
                         hours_map,
                         part=idx if isinstance(val, list) else None,
                         manual=manual,
-                        project_frozen=project.get('frozen', False),
                         project_blocked=project.get('blocked', False),
                         material_date=project.get('material_confirmed_date'),
                     )
@@ -748,28 +807,3 @@ def phase_start_map(projects):
         for worker, day, phase, hours, _ in items:
             result.setdefault(pid, {}).setdefault(phase, day)
     return result
-
-
-def previous_phase_end(projects, pid, phase, part=None):
-    """Return the last scheduled day of the phase immediately before ``phase``."""
-    if isinstance(part, str):
-        if part in ('', 'None'):
-            part = None
-        else:
-            try:
-                part = int(part)
-            except Exception:
-                part = None
-
-    mapping = compute_schedule_map(projects)
-    tasks = mapping.get(pid, [])
-    if not tasks:
-        return None
-    idx = PHASE_ORDER.index(phase)
-    last = None
-    for worker, day, ph, hours, prt in tasks:
-        dt = date.fromisoformat(day)
-        if ph in PHASE_ORDER[:idx]:
-            if not last or dt > last:
-                last = dt
-    return last

--- a/static/style.css
+++ b/static/style.css
@@ -18,6 +18,11 @@ table.schedule td.weekend-cell {
 }
 .ok { color: green; }
 .late { color: red; }
+.unplanned { color: orange; }
+.projects-table td.plan-col span {
+    font-size: 3em;
+    line-height: 1;
+}
 .split-dot {
     font-weight: bold;
     margin-right: 2px;
@@ -95,9 +100,8 @@ table.schedule td.weekend-cell {
     flex-direction: column;
     box-sizing: border-box;
 }
-.unplanned-panel h3 { display: flex; justify-content: space-between; align-items: center; }
+.unplanned-panel h3 { margin: 0; }
 .unplanned-list { overflow-y: auto; flex: 1; }
-#unplanned-show { display: none; position: fixed; right: 0; top: 100px; z-index: 1000; }
 .unplanned-resizer { position: absolute; left: 0; top: 0; bottom: 0; width: 5px; cursor: col-resize; background: #ccc; }
 .unplanned-folder { border: 1px solid #ccc; margin-bottom: 5px; }
 .unplanned-folder.dim { opacity: 0.3; }
@@ -121,6 +125,31 @@ table.schedule td.resource-col {
     width: 150px;
     border: 3px solid #000;
     font-weight: bold;
+}
+
+table.schedule td.resource-col {
+    font-size: 3em;
+    line-height: 1;
+}
+
+table.pedidos-calendar {
+    border-collapse: collapse;
+}
+table.pedidos-calendar th,
+table.pedidos-calendar td {
+    border: 1px solid #ccc;
+    padding: 4px;
+    width: 180px;
+    vertical-align: top;
+}
+table.pedidos-calendar td.week-label {
+    width: 80px;
+    font-weight: bold;
+    background: #eee;
+}
+.pedidos-calendar .day-number {
+    font-weight: bold;
+    margin-bottom: 2px;
 }
 
 /* keep projects table width */
@@ -175,7 +204,6 @@ table.schedule td.resource-col {
     background: #000;
 }
 
-.worker-toggle { cursor: pointer; margin-right: 4px; }
 tr.collapsed td:not(:first-child) { display: none; }
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,7 @@
     <nav>
         <a href="{{ url_for('complete') }}">Completo</a> |
         <a href="{{ url_for('calendar_view') }}">Calendario</a> |
+        <a href="{{ url_for('calendar_pedidos') }}">Calendario pedidos</a> |
         <a href="{{ url_for('project_list') }}">Proyectos</a> |
         <a href="{{ url_for('milestone_list') }}">Hitos</a> |
         <a href="{{ url_for('vacation_list') }}">Vacaciones</a> |

--- a/templates/calendar_pedidos.html
+++ b/templates/calendar_pedidos.html
@@ -1,0 +1,31 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Calendario pedidos</h2>
+<table class="pedidos-calendar">
+    <thead>
+    <tr>
+        <th>Semana</th>
+        <th>Lun</th>
+        <th>Mar</th>
+        <th>Mié</th>
+        <th>Jue</th>
+        <th>Vie</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for week in weeks %}
+    <tr>
+        <td class="week-label">Semana {{ week.number }}</td>
+        {% for d in week.days %}
+        <td class="{% if d.date == today %}today{% endif %}">
+            <div class="day-number">{{ d.ordinal }}</div>
+            {% for t in d.tasks %}
+            <div class="task" style="background-color: {{ t.color }};">{{ t.project }}{% if t.hours %} ({{ t.hours }}h){% endif %}</div>
+            {% endfor %}
+        </td>
+        {% endfor %}
+    </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/templates/complete.html
+++ b/templates/complete.html
@@ -172,7 +172,7 @@
         </div>
         <div class="unplanned-panel" id="unplanned-panel">
             <div id="unplanned-resizer" class="unplanned-resizer"></div>
-            <h3>Fases sin planificar <button type="button" id="unplanned-hide">&#187;</button></h3>
+            <h3>Fases sin planificar</h3>
             <div class="unplanned-list" data-worker="Sin planificar">
             {% for g in unplanned_with %}
             <div class="unplanned-folder" data-pid="{{ g.pid }}">
@@ -218,7 +218,6 @@
             </div>
         </div>
         </div>
-        <button id="unplanned-show" style="display:none;">Fases sin planificar</button>
         <div id="info-popup" class="info-popup"></div>
 <div id="conflict-modal" class="conflict-modal"><div class="conflict-content"><div id="conflict-text"></div><button id="conflict-close">Cerrar</button></div></div>
 <div id="material-modal" class="conflict-modal"><div class="conflict-content"><div id="material-text" style="color:red;font-weight:bold"></div><button id="material-close">Cerrar</button></div></div>
@@ -301,7 +300,7 @@
             </thead>
             <tbody>
             {% for p in projects %}
-            <tr data-pid="{{ p.id }}" class="{% if p.frozen %}frozen{% endif %}" style="background-color: {{ p.color }};">
+            <tr data-pid="{{ p.id }}" class="{% if p.frozen_tasks %}frozen{% endif %}" style="background-color: {{ p.color }};">
                 <td>{{ p.name }}</td>
                 <td>{{ p.client }}</td>
                 <td>
@@ -327,11 +326,13 @@
                         <span class="late">&#10060;</span>
                     {% endif %}
                 </td>
-                <td>
-                    {% if plan_map.get(p.id) %}
-                        <span class="ok">&#10004;</span>
+                <td class="plan-col">
+                    {% if p.plan_state == 'all' %}
+                        <span class="ok">&#9679;</span>
+                    {% elif p.plan_state == 'partial' %}
+                        <span class="unplanned">&#9679;</span>
                     {% else %}
-                        <span class="late">&#10060;</span>
+                        <span class="late">&#9679;</span>
                     {% endif %}
                 </td>
                 <td>{{ 'API' if p.source == 'api' else 'Manual' }}</td>
@@ -441,6 +442,7 @@
   const materialText = document.getElementById('material-text');
   const materialClose = document.getElementById('material-close');
   const filterForm = document.getElementById('filter-form');
+  const PROJECT_FILTER = {{ project_filter|tojson }};
   const hoursBtn = document.getElementById('hours-btn');
   const hoursRow = document.getElementById('hours-row');
   const thead = document.querySelector('.schedule thead');
@@ -472,12 +474,36 @@
 
   const wrapper = document.querySelector('.schedule-wrapper');
   const SCROLL_KEY = 'calendarScroll';
-  const savedScroll = sessionStorage.getItem(SCROLL_KEY);
-  if (savedScroll !== null) {
-    wrapper.scrollLeft = parseFloat(savedScroll);
+  if (PROJECT_FILTER) {
+    const projTasks = document.querySelectorAll('.schedule .task');
+    if (projTasks.length) {
+      let earliest = projTasks[0];
+      let earliestDate = new Date(projTasks[0].dataset.day);
+      projTasks.forEach(t => {
+        const dt = new Date(t.dataset.day);
+        if (dt < earliestDate) {
+          earliestDate = dt;
+          earliest = t;
+        }
+      });
+      earliest.scrollIntoView({behavior: 'auto', inline: 'center'});
+    } else {
+      const savedScroll = sessionStorage.getItem(SCROLL_KEY);
+      if (savedScroll !== null) {
+        wrapper.scrollLeft = parseFloat(savedScroll);
+      } else {
+        const todayCell = document.querySelector('th.today');
+        if (todayCell) todayCell.scrollIntoView({behavior: 'auto', inline: 'center'});
+      }
+    }
   } else {
-    const todayCell = document.querySelector('th.today');
-    if (todayCell) todayCell.scrollIntoView({behavior: 'auto', inline: 'center'});
+    const savedScroll = sessionStorage.getItem(SCROLL_KEY);
+    if (savedScroll !== null) {
+      wrapper.scrollLeft = parseFloat(savedScroll);
+    } else {
+      const todayCell = document.querySelector('th.today');
+      if (todayCell) todayCell.scrollIntoView({behavior: 'auto', inline: 'center'});
+    }
   }
   wrapper.addEventListener('scroll', () => {
     sessionStorage.setItem(SCROLL_KEY, wrapper.scrollLeft);
@@ -564,7 +590,7 @@
         }
         html += `</div>`;
         html += `<div><form id="start-form" style="display:inline"><input type="date" id="start-input" value="${startVal}" required><button type="submit" id="start-btn" data-pid="${t.dataset.pid}" data-phase="${t.dataset.phase}">Cambiar</button></form></div>`;
-        html += `<div><button id="freeze-btn" data-pid="${t.dataset.pid}" style="color:red;font-weight:bold">${info.frozen ? 'Descongelar' : 'Congelar'}</button></div>`;
+        html += `<div><button id="freeze-btn" data-pid="${t.dataset.pid}" data-phase="${t.dataset.phase}" style="color:red;font-weight:bold">${(info.frozen_phases && info.frozen_phases.includes(t.dataset.phase)) ? 'Descongelar' : 'Congelar'}</button></div>`;
         html += `<div><button id="split-btn" data-pid="${t.dataset.pid}" data-phase="${t.dataset.phase}" data-date="${t.dataset.day}">Dividir fase aquí</button>`;
         if (Array.isArray(info.phases[t.dataset.phase])) {
           html += ` <button id="unsplit-btn" data-pid="${t.dataset.pid}" data-phase="${t.dataset.phase}">Deshacer división</button>`;
@@ -641,7 +667,7 @@
       if (freeze) {
         freeze.addEventListener('click', ev => {
           ev.stopPropagation();
-          fetch('/toggle_freeze/' + freeze.dataset.pid, {
+          fetch('/toggle_freeze/' + freeze.dataset.pid + '/' + encodeURIComponent(freeze.dataset.phase), {
             method: 'POST',
             credentials: 'same-origin'
           }).then(() => location.reload());
@@ -734,6 +760,13 @@
         } else {
           t.classList.add('dim');
           t.classList.remove('highlight');
+        }
+      });
+      folders.forEach(f => {
+        if (f.dataset.pid === pid) {
+          f.classList.remove('dim');
+        } else {
+          f.classList.add('dim');
         }
       });
     });
@@ -831,6 +864,21 @@
     const t = Array.from(tasks).find(o => o.dataset.pid === stored);
     if (t) {
       showTask(t);
+    } else {
+      const row = Array.from(rows).find(r => r.dataset.pid === stored);
+      if (row) {
+        row.dispatchEvent(new Event('click'));
+      } else {
+        const folder = Array.from(folders).find(f => f.dataset.pid === stored);
+        if (folder) {
+          folders.forEach(f => {
+            if (f === folder) f.classList.remove('dim');
+            else f.classList.add('dim');
+          });
+        } else {
+          folders.forEach(f => f.classList.add('dim'));
+        }
+      }
     }
     sessionStorage.removeItem('highlightPid');
   }
@@ -927,15 +975,12 @@
           materialModal.style.display = 'block';
           materialClose.onclick = () => { materialModal.style.display = 'none'; location.reload(); };
         } else {
-          if (data.message) alert(data.message);
           location.reload();
         }
       });
     });
   });
   const unplanPanel = document.getElementById('unplanned-panel');
-  const unplanHide = document.getElementById('unplanned-hide');
-  const unplanShow = document.getElementById('unplanned-show');
   const unplanResizer = document.getElementById('unplanned-resizer');
   const UNPLAN_WIDTH_KEY = 'unplannedWidth';
 
@@ -953,22 +998,6 @@
     if (savedWidth) {
       unplanPanel.style.width = savedWidth + 'px';
     }
-  }
-  if (unplanPanel && unplanHide && unplanShow) {
-    unplanHide.addEventListener('click', () => {
-      localStorage.setItem(UNPLAN_WIDTH_KEY, unplanPanel.offsetWidth);
-      unplanPanel.style.display = 'none';
-      unplanShow.style.display = 'block';
-    });
-    unplanShow.addEventListener('click', () => {
-      const saved = localStorage.getItem(UNPLAN_WIDTH_KEY);
-      if (saved) {
-        unplanPanel.style.width = saved + 'px';
-      }
-      unplanPanel.style.display = 'block';
-      unplanShow.style.display = 'none';
-      syncUnplannedHeight();
-    });
   }
   if (unplanPanel && unplanResizer) {
     let startX, startWidth;

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,9 +9,13 @@
     </form>
     <button id="today-btn">HOY</button>
 </div>
+<div class="bug-btn-container">
+    <button id="bug-btn" class="bug-btn" type="button">Reportar bug</button>
+</div>
 <div class="hours-btn-container">
     <button id="hours-btn" type="button">Editar jornada laboral</button>
 </div>
+<div class="calendar-flex">
 <div class="schedule-wrapper">
 <table class="schedule">
     <thead>
@@ -47,7 +51,7 @@
     <tbody>
 {% for worker, days_data in schedule.items() %}
     <tr data-worker="{{ worker }}">
-        <td class="resource-col"><span class="worker-toggle">&#8722;</span><strong>{{ worker.upper() }}</strong> ({{ workers[worker]|join(', ') }})</td>
+        <td class="resource-col">{{ worker }}</td>
         {% for c in cols %}
         {% if c.type == 'day' %}
         {% set d = c.dates[0] %}
@@ -55,7 +59,7 @@
             {% set tasks = days_data.get(d.isoformat(), []) %}
             {% for t in tasks %}
             {% if t.phase == 'vacaciones' %}
-            <div class="task vacation">VACACIONES</div>
+            <div class="task vacation" data-worker="{{ worker }}" data-day="{{ d.isoformat() }}">VACACIONES<br><span class="vac-delete" style="display:none;">X</span></div>
             {% else %}
             <div class="task{% if t.frozen %} frozen{% endif %}" draggable="{{ 'false' if t.frozen else 'true' }}" style="background-color: {{ t.color }};" data-project="{{ t.project }}" data-client="{{ t.client }}" data-due="{{ t.due_date }}" data-start="{{ t.start_date }}" data-day="{{ d.isoformat() }}" data-priority="{{ t.priority }}" data-pid="{{ t.pid }}" data-phase="{{ t.phase }}" data-part="{{ t.part }}">
                 {% if t.late %}
@@ -110,9 +114,95 @@
     </tfoot>
 </table>
 </div>
+        <div class="unplanned-panel" id="unplanned-panel">
+            <div id="unplanned-resizer" class="unplanned-resizer"></div>
+            <h3>Fases sin planificar</h3>
+            <div class="unplanned-list" data-worker="Sin planificar">
+            {% for g in unplanned_with %}
+            <div class="unplanned-folder" data-pid="{{ g.pid }}">
+                <div class="folder-header"><button type="button" class="folder-toggle">&#43;</button> {{ g.project }} - {{ g.client }}</div>
+                <div class="folder-content" style="display:none;">
+                {% for t in g.tasks %}
+                <div class="task{% if t.frozen %} frozen{% endif %}" draggable="true" style="background-color: {{ t.color }};" data-project="{{ t.project }}" data-client="{{ t.client }}" data-due="{{ t.due_date }}" data-start="{{ t.start_date }}" data-day="{{ t.day }}" data-priority="{{ t.priority }}" data-pid="{{ t.pid }}" data-phase="{{ t.phase }}"{% if t.part %} data-part="{{ t.part }}"{% endif %}>
+                    {% if t.late %}
+                        <span class="late">&#10060;</span>
+                    {% else %}
+                        <span class="ok">&#10004;</span>
+                    {% endif %}
+                    {% set key = t.pid ~ '|' ~ t.phase ~ '|' ~ t.day %}
+                    {% if key in split_points %}<span class="split-dot">&#9679;</span> {% endif %}
+                    {{ t.project }}{% if t.blocked %}<span class="blocked-sign">&#128683;</span>{% endif %} - {{ t.client }} - {{ t.phase }}{% if t.hours %} ({{ t.hours }}h){% endif %}
+                </div>
+                {% endfor %}
+                </div>
+            </div>
+            {% endfor %}
+            {% if unplanned_with and unplanned_without %}
+            <hr class="unplanned-divider" />
+            {% endif %}
+            {% for g in unplanned_without %}
+            <div class="unplanned-folder" data-pid="{{ g.pid }}">
+                <div class="folder-header"><button type="button" class="folder-toggle">&#43;</button> {{ g.project }} - {{ g.client }}</div>
+                <div class="folder-content" style="display:none;">
+                {% for t in g.tasks %}
+                <div class="task{% if t.frozen %} frozen{% endif %}" draggable="true" style="background-color: {{ t.color }};" data-project="{{ t.project }}" data-client="{{ t.client }}" data-due="{{ t.due_date }}" data-start="{{ t.start_date }}" data-day="{{ t.day }}" data-priority="{{ t.priority }}" data-pid="{{ t.pid }}" data-phase="{{ t.phase }}"{% if t.part %} data-part="{{ t.part }}"{% endif %}>
+                    {% if t.late %}
+                        <span class="late">&#10060;</span>
+                    {% else %}
+                        <span class="ok">&#10004;</span>
+                    {% endif %}
+                    {% set key = t.pid ~ '|' ~ t.phase ~ '|' ~ t.day %}
+                    {% if key in split_points %}<span class="split-dot">&#9679;</span> {% endif %}
+                    {{ t.project }}{% if t.blocked %}<span class="blocked-sign">&#128683;</span>{% endif %} - {{ t.client }} - {{ t.phase }}{% if t.hours %} ({{ t.hours }}h){% endif %}
+                </div>
+                {% endfor %}
+                </div>
+            </div>
+            {% endfor %}
+            </div>
+        </div>
+</div>
 <div id="info-popup" class="info-popup"></div>
 <div id="conflict-modal" class="conflict-modal"><div class="conflict-content"><div id="conflict-text"></div><button id="conflict-close">Cerrar</button></div></div>
 <div id="material-modal" class="conflict-modal"><div class="conflict-content"><div id="material-text" style="color:red;font-weight:bold"></div><button id="material-close">Cerrar</button></div></div>
+<div id="bug-modal" class="modal">
+    <div class="modal-content">
+        <form id="bug-form" method="post" action="{{ url_for('report_bug') }}">
+            <label>Quién lo registra:
+                <select name="user" required>
+                    <option value="Unai">Unai</option>
+                    <option value="Pilar">Pilar</option>
+                    <option value="Ane">Ane</option>
+                    <option value="Irene">Irene</option>
+                </select>
+            </label><br>
+            <label>Pestaña:
+                <select name="tab" required>
+                    <option value="Completo">Completo</option>
+                    <option value="Calendario" selected>Calendario</option>
+                    <option value="Proyectos">Proyectos</option>
+                    <option value="Hitos">Hitos</option>
+                    <option value="Vacaciones">Vacaciones</option>
+                </select>
+            </label><br>
+            <label>Frecuencia:
+                <select name="freq" required>
+                    <option>Primera vez</option>
+                    <option>Un par</option>
+                    <option>Bastante a menudo</option>
+                    <option>Siempre. Estoy hasta los cojones.</option>
+                </select>
+            </label><br>
+            <label>Descripción:<br>
+                <textarea name="detail" rows="5" cols="40" required></textarea>
+            </label><br>
+            <div style="text-align:right;">
+                <button type="submit">Enviar</button>
+                <button type="button" id="bug-cancel">Cancelar</button>
+            </div>
+        </form>
+    </div>
+</div>
 
 <h3>Conflictos</h3>
 <form method="post" action="{{ url_for('clear_conflicts') }}">
@@ -163,22 +253,45 @@
   const materialText = document.getElementById('material-text');
   const materialClose = document.getElementById('material-close');
   const filterForm = document.getElementById('filter-form');
-
+  const PROJECT_FILTER = {{ project_filter|tojson }};
 
   // allow horizontal scrolling with Shift + wheel over the schedule
   const wrapper = document.querySelector('.schedule-wrapper');
   const SCROLL_KEY = 'calendarScroll';
-  const savedScroll = sessionStorage.getItem(SCROLL_KEY);
-  if (savedScroll !== null) {
-    wrapper.scrollLeft = parseFloat(savedScroll);
+  if (PROJECT_FILTER) {
+    const projTasks = document.querySelectorAll('.schedule .task');
+    if (projTasks.length) {
+      let earliest = projTasks[0];
+      let earliestDate = new Date(projTasks[0].dataset.day);
+      projTasks.forEach(t => {
+        const dt = new Date(t.dataset.day);
+        if (dt < earliestDate) {
+          earliestDate = dt;
+          earliest = t;
+        }
+      });
+      earliest.scrollIntoView({behavior: 'auto', inline: 'center'});
+    } else {
+      const savedScroll = sessionStorage.getItem(SCROLL_KEY);
+      if (savedScroll !== null) {
+        wrapper.scrollLeft = parseFloat(savedScroll);
+      } else {
+        const todayCell = document.querySelector('th.today');
+        if (todayCell) todayCell.scrollIntoView({behavior: 'auto', inline: 'center'});
+      }
+    }
   } else {
-    const todayCell = document.querySelector('th.today');
-    if (todayCell) todayCell.scrollIntoView({behavior: 'auto', inline: 'center'});
+    const savedScroll = sessionStorage.getItem(SCROLL_KEY);
+    if (savedScroll !== null) {
+      wrapper.scrollLeft = parseFloat(savedScroll);
+    } else {
+      const todayCell = document.querySelector('th.today');
+      if (todayCell) todayCell.scrollIntoView({behavior: 'auto', inline: 'center'});
+    }
   }
   wrapper.addEventListener('scroll', () => {
     sessionStorage.setItem(SCROLL_KEY, wrapper.scrollLeft);
   });
-  const collapsedSet = new Set(JSON.parse(localStorage.getItem('collapsedWorkers') || '[]'));
   const hoursBtn = document.getElementById('hours-btn');
   const hoursRow = document.getElementById('hours-row');
   const thead = document.querySelector('.schedule thead');
@@ -203,14 +316,6 @@
     });
   });
 
-  document.querySelectorAll('tbody tr[data-worker]').forEach(tr => {
-    const worker = tr.dataset.worker;
-    const btn = tr.querySelector('.worker-toggle');
-    if (collapsedSet.has(worker)) {
-      tr.classList.add('collapsed');
-      if (btn) btn.textContent = '+';
-    }
-  });
   wrapper.addEventListener('wheel', (e) => {
     if (!e.shiftKey) return;
     e.preventDefault();
@@ -226,6 +331,7 @@
   });
 
   const tasks = document.querySelectorAll('.task');
+  const folders = document.querySelectorAll('.unplanned-folder');
   const popup = document.getElementById('info-popup');
   let lastDrag = null;
   tasks.forEach(t => {
@@ -251,6 +357,13 @@
         } else {
           o.classList.add('dim');
           o.classList.remove('highlight');
+        }
+      });
+      folders.forEach(f => {
+        if (f.dataset.pid === t.dataset.pid) {
+          f.classList.remove('dim');
+        } else {
+          f.classList.add('dim');
         }
       });
       const info = PROJECT_DATA[t.dataset.pid];
@@ -279,7 +392,7 @@
       }
       html += `</div>`;
       html += `<div><form id="start-form" style="display:inline"><input type="date" id="start-input" value="${startVal}" required><button type="submit" id="start-btn" data-pid="${t.dataset.pid}" data-phase="${t.dataset.phase}">Cambiar</button></form></div>`;
-      html += `<div><button id="freeze-btn" data-pid="${t.dataset.pid}" style="color:red;font-weight:bold">${info.frozen ? 'Descongelar' : 'Congelar'}</button></div>`;
+      html += `<div><button id="freeze-btn" data-pid="${t.dataset.pid}" data-phase="${t.dataset.phase}" style="color:red;font-weight:bold">${(info.frozen_phases && info.frozen_phases.includes(t.dataset.phase)) ? 'Descongelar' : 'Congelar'}</button></div>`;
       html += `<div><button id="split-btn" data-pid="${t.dataset.pid}" data-phase="${t.dataset.phase}" data-date="${t.dataset.day}">Dividir fase aquí</button>`;
       if (Array.isArray(info.phases[t.dataset.phase])) {
         html += ` <button id="unsplit-btn" data-pid="${t.dataset.pid}" data-phase="${t.dataset.phase}">Deshacer división</button>`;
@@ -360,7 +473,7 @@
       if (freeze) {
         freeze.addEventListener('click', ev => {
           ev.stopPropagation();
-          fetch('/toggle_freeze/' + freeze.dataset.pid, { method: 'POST', credentials: 'same-origin' })
+          fetch('/toggle_freeze/' + freeze.dataset.pid + '/' + encodeURIComponent(freeze.dataset.phase), { method: 'POST', credentials: 'same-origin' })
             .then(() => location.reload());
         });
       }
@@ -441,24 +554,10 @@
   });
   document.addEventListener('click', () => {
     tasks.forEach(o => o.classList.remove('highlight', 'dim'));
+    folders.forEach(f => f.classList.remove('dim'));
     popup.style.display = 'none';
   });
   popup.addEventListener('click', (e) => e.stopPropagation());
-  document.querySelectorAll('.worker-toggle').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const tr = btn.closest('tr');
-      const worker = tr.dataset.worker;
-      tr.classList.toggle('collapsed');
-      if (tr.classList.contains('collapsed')) {
-        collapsedSet.add(worker);
-        btn.textContent = '+';
-      } else {
-        collapsedSet.delete(worker);
-        btn.textContent = '−';
-      }
-      localStorage.setItem('collapsedWorkers', JSON.stringify(Array.from(collapsedSet)));
-    });
-  });
   function showTask(t) {
     t.dispatchEvent(new Event('click'));
     const rect = t.getBoundingClientRect();
@@ -481,6 +580,16 @@
     const t = Array.from(tasks).find(o => o.dataset.pid === stored);
     if (t) {
       showTask(t);
+    } else {
+      const folder = Array.from(folders).find(f => f.dataset.pid === stored);
+      if (folder) {
+        folders.forEach(f => {
+          if (f === folder) f.classList.remove('dim');
+          else f.classList.add('dim');
+        });
+      } else {
+        folders.forEach(f => f.classList.add('dim'));
+      }
     }
     sessionStorage.removeItem('highlightPid');
   }
@@ -577,12 +686,84 @@
           materialModal.style.display = 'block';
           materialClose.onclick = () => { materialModal.style.display = 'none'; location.reload(); };
         } else {
-          if (data.message) alert(data.message);
           location.reload();
         }
       });
       });
     });
+  const unplanPanel = document.getElementById('unplanned-panel');
+  const unplanResizer = document.getElementById('unplanned-resizer');
+  const UNPLAN_WIDTH_KEY = 'unplannedWidth';
+
+  function syncUnplannedHeight() {
+    const wrap = document.querySelector('.schedule-wrapper');
+    if (wrap && unplanPanel) {
+      unplanPanel.style.height = wrap.offsetHeight + 'px';
+    }
+  }
+
+  syncUnplannedHeight();
+  window.addEventListener('resize', syncUnplannedHeight);
+  if (unplanPanel) {
+    const savedWidth = localStorage.getItem(UNPLAN_WIDTH_KEY);
+    if (savedWidth) {
+      unplanPanel.style.width = savedWidth + 'px';
+    }
+  }
+  if (unplanPanel && unplanResizer) {
+    let startX, startWidth;
+    const onMouseMove = (e) => {
+      const dx = startX - e.clientX;
+      const newWidth = Math.max(100, startWidth + dx);
+      unplanPanel.style.width = newWidth + 'px';
+    };
+    const onMouseUp = () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      localStorage.setItem(UNPLAN_WIDTH_KEY, unplanPanel.offsetWidth);
+    };
+    unplanResizer.addEventListener('mousedown', (e) => {
+      startX = e.clientX;
+      startWidth = unplanPanel.offsetWidth;
+      document.addEventListener('mousemove', onMouseMove);
+      document.addEventListener('mouseup', onMouseUp);
+    });
+  }
+  document.querySelectorAll('.task.vacation').forEach(div => {
+    div.addEventListener('click', () => {
+      const del = div.querySelector('.vac-delete');
+      if (del) del.style.display = 'block';
+    });
+  });
+  document.querySelectorAll('.vac-delete').forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const parent = btn.parentElement;
+      const worker = parent.dataset.worker;
+      const day = parent.dataset.day;
+      fetch('/remove_vacation', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        body: `worker=${encodeURIComponent(worker)}&date=${encodeURIComponent(day)}`
+      }).then(() => location.reload());
+    });
+  });
+  document.querySelectorAll('.folder-toggle').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const content = btn.parentElement.nextElementSibling;
+      const hidden = content.style.display === 'none';
+      content.style.display = hidden ? 'block' : 'none';
+      btn.innerHTML = hidden ? '&#8722;' : '&#43;';
+    });
+  });
+  const bugBtn = document.getElementById('bug-btn');
+  const bugModal = document.getElementById('bug-modal');
+  const bugCancel = document.getElementById('bug-cancel');
+  if (bugBtn && bugModal) {
+    bugBtn.addEventListener('click', () => { bugModal.style.display = 'block'; });
+    bugCancel.addEventListener('click', () => { bugModal.style.display = 'none'; });
+    bugModal.addEventListener('click', (e) => { if (e.target === bugModal) bugModal.style.display = 'none'; });
+  }
 const CONFLICTS = {{ conflicts|tojson }};
 const conflictModal = document.getElementById("conflict-modal");
 const conflictText = document.getElementById("conflict-text");

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -41,7 +41,7 @@
     </thead>
     <tbody>
     {% for p in projects %}
-    <tr data-pid="{{ p.id }}" class="{% if p.frozen %}frozen{% endif %}" style="background-color: {{ p.color }};">
+    <tr data-pid="{{ p.id }}" class="{% if p.frozen_tasks %}frozen{% endif %}" style="background-color: {{ p.color }};">
         <td>{{ p.name }}{% if p.blocked %}<span class="blocked-sign">&#128683;</span>{% endif %}</td>
         <td>{{ p.client }}</td>
         <td>
@@ -67,11 +67,13 @@
                 <span class="late">&#10060;</span>
             {% endif %}
         </td>
-        <td>
-            {% if p.planned %}
-                <span class="ok">&#10004;</span>
+        <td class="plan-col">
+            {% if p.plan_state == 'all' %}
+                <span class="ok">&#9679;</span>
+            {% elif p.plan_state == 'partial' %}
+                <span class="unplanned">&#9679;</span>
             {% else %}
-                <span class="late">&#10060;</span>
+                <span class="late">&#9679;</span>
             {% endif %}
         </td>
         <td>{{ 'API' if p.source == 'api' else 'Manual' }}</td>

--- a/templates/resources.html
+++ b/templates/resources.html
@@ -11,6 +11,10 @@
     </tr>
     {% endfor %}
   </table>
+  <div class="add-worker">
+    <input type="text" name="new_worker" placeholder="Nombre del recurso">
+    <button type="submit" name="add_worker">Añadir recurso</button>
+  </div>
   <button type="submit">Guardar</button>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add a "Calendario pedidos" tab that presents weeks Monday–Friday with week numbers and day-of-year labels for scheduled pedidos phases.
- Triple calendar resource names for easier identification by setting `td.resource-col` font-size to 3em.
- Keep "Fases sin planificar" column always visible and mirror the Completo calendar in Calendario.
- Allow placing phases before their predecessors after showing an orange "ORDEN INADECUADO DE FASES" popup; starting after due dates is also allowed.
- Remove availability validation that returned "El día seleccionado no estaba disponible" so scheduling on booked days proceeds without error.
- Auto-scroll to the earliest planned phase when filtering the calendar by project.
- Mark projects with unplanned phases by showing an orange "X" in the Planificado column only when some phases remain unscheduled.
- Ignore Kanbanize updates for phases that were deleted locally so removed phases are not reintroduced.
- Indicate planning completeness with a green, orange, or red circle in the Planificado column.
- Highlight selected projects in the "Fases sin planificar" panel or dim all if they have no unplanned phases.
- Make Planificado status circles three times larger for better visibility.
- Let users add new resources from the Recursos tab; added names appear below Eneko and can be toggled active or inactive in the calendar.
- Freeze only the phase selected by the user, leaving the rest of the project editable.
- Drop phase execution ordering so manual start overrides now set the exact start date for any phase, including "pedidos".
- Deleting a project now preserves the schedule of all remaining projects instead of reorganizing them.

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68949dbff3fc8325bff2a513554d5644