### PR TITLE
Default project worker selectors to 'Sin planificar'

### DIFF
--- a/app.py
+++ b/app.py
@@ -998,7 +998,7 @@ def project_list():
         projects=projects,
         priorities=list(PRIORITY_ORDER.keys()),
         phases=PHASE_ORDER,
-        all_workers=active_workers() + [UNPLANNED],
+        all_workers=[UNPLANNED] + active_workers(),
         project_filter=project_filter,
         client_filter=client_filter,
         sort_option=sort_option,

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -90,9 +90,10 @@
             {% endif %}
                 <form method="post" action="{{ url_for('update_worker', pid=p.id, phase=ph) }}">
                     <input type="hidden" name="next" value="{{ url_for('project_list') }}">
+                    {% set assigned = p.assigned.get(ph) if p.assigned and p.assigned.get(ph) else 'Sin planificar' %}
                     <select name="worker">
                         {% for w in all_workers %}
-                            <option value="{{ w }}" {% if p.assigned and p.assigned.get(ph) == w %}selected{% endif %}>{{ w }}</option>
+                            <option value="{{ w }}" {% if assigned == w %}selected{% endif %}>{{ w }}</option>
                         {% endfor %}
                     </select>
                 </form>


### PR DESCRIPTION
## Summary
- Show 'Sin planificar' when no worker is assigned in project list selectors
- List the unplanned option first for easier access

## Testing
- `python -m py_compile app.py && echo "py_compile success"`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aec8e12d1883258c10702d5703b5f5