### PR TITLE
Filter hidden order columns from calendar

### DIFF
--- a/app.py
+++ b/app.py
@@ -152,6 +152,12 @@ PEDIDOS_ALLOWED_COLUMNS = {
     'Material NO CONFORME',
 }
 
+PEDIDOS_HIDDEN_COLUMNS = [
+    "Ready to Archive",
+    "Material recepcionado",
+    "Pdte. Verificación",
+]
+
 PEDIDOS_UNCONFIRMED_COLUMNS = {
     'Tau',
     'Bekola',
@@ -1183,7 +1189,11 @@ def calendar_pedidos():
         }
 
         # --- CALENDARIO PRINCIPAL ---
-        if lane_name.strip() == "Seguimiento compras" and column in PEDIDOS_ALLOWED_COLUMNS:
+        if (
+            lane_name.strip().lower() == "seguimiento compras"
+            and column in PEDIDOS_ALLOWED_COLUMNS
+            and column not in PEDIDOS_HIDDEN_COLUMNS
+        ):
             if d:  # con fecha
                 pedidos.setdefault(d, []).append(entry)
 


### PR DESCRIPTION
## Summary
- add `PEDIDOS_HIDDEN_COLUMNS` list for columns that should not appear in orders calendar
- skip hidden columns and normalize lane names when populating calendar entries

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b816ba05c08325a8e79cdf601ca232