### PR TITLE
Handle kanban deadline warnings for fecha tope and fecha cliente

### DIFF
--- a/app.py
+++ b/app.py
@@ -66,7 +66,8 @@ WEEKEND = _schedule_mod.WEEKEND
 HOURS_PER_DAY = _schedule_mod.HOURS_PER_DAY
 HOURS_LIMITS = _schedule_mod.HOURS_LIMITS
 next_workday = _schedule_mod.next_workday
-DEADLINE_MSG = 'FECHA LÍMITE CONFIRMADA A CLIENTE, NO SOBREPASAR.'
+DEADLINE_MSG = 'FECHA TOPE SOBREPASADA.'
+CLIENT_DEADLINE_MSG = 'Fecha cliente soprepasada.'
 
 app = Flask(__name__)
 app.url_map.strict_slashes = False
@@ -631,7 +632,7 @@ def move_phase_date(
     ):
         return None, 'Vacaciones en esa fecha'
     warning = None
-    if proj.get('due_confirmed') and proj.get('due_date'):
+    if proj.get('due_date'):
         try:
             due_dt = date.fromisoformat(proj['due_date'])
             phase_hours = proj['phases'].get(phase)
@@ -646,7 +647,8 @@ def move_phase_date(
             for _ in range(days_needed - 1):
                 test_end = next_workday(test_end)
             if test_end > due_dt:
-                warning = f"{DEADLINE_MSG}\n{proj['name']} - {proj['client']} - {due_dt.strftime('%Y-%m-%d')}"
+                msg = CLIENT_DEADLINE_MSG if proj.get('due_confirmed') else DEADLINE_MSG
+                warning = f"{msg}\n{proj['name']} - {proj['client']} - {due_dt.strftime('%Y-%m-%d')}"
         except Exception:
             pass
     # Apply the change to the real project list

--- a/templates/complete.html
+++ b/templates/complete.html
@@ -418,7 +418,8 @@
   const deadlineModal = document.getElementById('deadline-modal');
   const deadlineText = document.getElementById('deadline-text');
   const deadlineClose = document.getElementById('deadline-close');
-  const DEADLINE_MSG = 'FECHA LÍMITE CONFIRMADA A CLIENTE, NO SOBREPASAR.';
+  const DEADLINE_MSG = 'FECHA TOPE SOBREPASADA.';
+  const CLIENT_DEADLINE_MSG = 'Fecha cliente soprepasada.';
   const splitModal = document.getElementById('split-modal');
   const splitForm = document.getElementById('split-form');
   const splitPart1 = document.getElementById('split-part1');
@@ -439,6 +440,7 @@
   let pendingBlock = null;
   function showDeadline(text = DEADLINE_MSG, after = null) {
     deadlineText.innerHTML = text.replace(/\n/g, '<br>');
+    deadlineText.style.color = text.startsWith(CLIENT_DEADLINE_MSG) ? 'black' : 'orange';
     deadlineModal.style.display = 'block';
     deadlineClose.onclick = () => { deadlineModal.style.display = 'none'; if (after) after(); };
   }
@@ -448,7 +450,8 @@
 
   for (const [pid, proj] of Object.entries(PROJECT_DATA)) {
     if (proj.due_warning) {
-      const text = `${DEADLINE_MSG}\n${proj.name} - ${proj.client} - ${proj.due_date}`;
+      const msg = proj.due_confirmed ? CLIENT_DEADLINE_MSG : DEADLINE_MSG;
+      const text = `${msg}\n${proj.name} - ${proj.client} - ${proj.due_date}`;
       showDeadline(text, () => {
         fetch(CLEAR_DEADLINE_URL, {
           method: 'POST',
@@ -694,7 +697,7 @@ const popup = document.getElementById('info-popup');
             .then(resp => resp.json().then(d => ({ ok: resp.ok, data: d })))
             .then(({ ok, data }) => {
               if (!ok) {
-                if (data.error === DEADLINE_MSG) showDeadline();
+                if (data.error === DEADLINE_MSG || data.error === CLIENT_DEADLINE_MSG) showDeadline(data.error);
                 else alert(data.error || 'Error');
                 return;
               }
@@ -966,7 +969,7 @@ const popup = document.getElementById('info-popup');
           .then(resp => resp.json().then(d => ({ ok: resp.ok, data: d })))
           .then(({ ok, data }) => {
             if (!ok) {
-              if (data.error === DEADLINE_MSG) showDeadline();
+              if (data.error === DEADLINE_MSG || data.error === CLIENT_DEADLINE_MSG) showDeadline(data.error);
               else alert(data.error || 'Error');
               return;
             }
@@ -1074,7 +1077,7 @@ const popup = document.getElementById('info-popup');
           blockModal.style.display = 'block';
           return;
         }
-        if (data.error === DEADLINE_MSG) showDeadline();
+        if (data.error === DEADLINE_MSG || data.error === CLIENT_DEADLINE_MSG) showDeadline(data.error);
         else alert(data.error || 'Error');
         return;
       }
@@ -1162,7 +1165,7 @@ const popup = document.getElementById('info-popup');
         .then(resp => resp.json().then(d => ({ ok: resp.ok, data: d })))
         .then(({ ok, data }) => {
           if (!ok) {
-            if (data.error === DEADLINE_MSG) showDeadline();
+            if (data.error === DEADLINE_MSG || data.error === CLIENT_DEADLINE_MSG) showDeadline(data.error);
             else alert(data.error || 'Error');
             return;
           }

--- a/templates/index.html
+++ b/templates/index.html
@@ -287,7 +287,8 @@
   const deadlineModal = document.getElementById('deadline-modal');
   const deadlineText = document.getElementById('deadline-text');
   const deadlineClose = document.getElementById('deadline-close');
-  const DEADLINE_MSG = 'FECHA LÍMITE CONFIRMADA A CLIENTE, NO SOBREPASAR.';
+  const DEADLINE_MSG = 'FECHA TOPE SOBREPASADA.';
+  const CLIENT_DEADLINE_MSG = 'Fecha cliente soprepasada.';
   const splitModal = document.getElementById('split-modal');
   const splitForm = document.getElementById('split-form');
   const splitPart1 = document.getElementById('split-part1');
@@ -308,6 +309,7 @@
   let pendingBlock = null;
   function showDeadline(text = DEADLINE_MSG, after = null) {
     deadlineText.innerHTML = text.replace(/\n/g, '<br>');
+    deadlineText.style.color = text.startsWith(CLIENT_DEADLINE_MSG) ? 'black' : 'orange';
     deadlineModal.style.display = 'block';
     deadlineClose.onclick = () => { deadlineModal.style.display = 'none'; if (after) after(); };
   }
@@ -317,7 +319,8 @@
 
   for (const [pid, proj] of Object.entries(PROJECT_DATA)) {
     if (proj.due_warning) {
-      const text = `${DEADLINE_MSG}\n${proj.name} - ${proj.client} - ${proj.due_date}`;
+      const msg = proj.due_confirmed ? CLIENT_DEADLINE_MSG : DEADLINE_MSG;
+      const text = `${msg}\n${proj.name} - ${proj.client} - ${proj.due_date}`;
       showDeadline(text, () => {
         fetch(CLEAR_DEADLINE_URL, {
           method: 'POST',
@@ -556,7 +559,7 @@ let lastDrag = null;
             .then(resp => resp.json().then(d => ({ ok: resp.ok, data: d })))
             .then(({ ok, data }) => {
               if (!ok) {
-                if (data.error === DEADLINE_MSG) showDeadline();
+                if (data.error === DEADLINE_MSG || data.error === CLIENT_DEADLINE_MSG) showDeadline(data.error);
                 else alert(data.error || 'Error');
                 return;
               }
@@ -754,7 +757,7 @@ let lastDrag = null;
           .then(resp => resp.json().then(d => ({ ok: resp.ok, data: d })))
           .then(({ ok, data }) => {
             if (!ok) {
-              if (data.error === DEADLINE_MSG) showDeadline();
+              if (data.error === DEADLINE_MSG || data.error === CLIENT_DEADLINE_MSG) showDeadline(data.error);
               else alert(data.error || 'Error');
               return;
             }
@@ -862,7 +865,7 @@ let lastDrag = null;
           blockModal.style.display = 'block';
           return;
         }
-        if (data.error === DEADLINE_MSG) showDeadline();
+        if (data.error === DEADLINE_MSG || data.error === CLIENT_DEADLINE_MSG) showDeadline(data.error);
         else alert(data.error || 'Error');
         return;
       }
@@ -950,7 +953,7 @@ let lastDrag = null;
         .then(resp => resp.json().then(d => ({ ok: resp.ok, data: d })))
         .then(({ ok, data }) => {
           if (!ok) {
-            if (data.error === DEADLINE_MSG) showDeadline();
+            if (data.error === DEADLINE_MSG || data.error === CLIENT_DEADLINE_MSG) showDeadline(data.error);
             else alert(data.error || 'Error');
             return;
           }


### PR DESCRIPTION
## Summary
- Distinguish between Kanban 'fecha tope' and 'fecha cliente' when moving phases past their deadlines
- Show black warning popup for 'fecha cliente' and allow movement with a separate warning for 'fecha tope'

## Testing
- `python -m py_compile app.py schedule.py`


------
https://chatgpt.com/codex/tasks/task_e_68b95bdfc0b883259c29f6e085abc23d