### PR TITLE
Resaltar celdas incompletas con borde superior rojo

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -11,7 +11,8 @@ table.schedule th, table.schedule td {
     min-width: 300px;
 }
 table.schedule td.incomplete {
-    border: 3px solid #000;
+    border: 1px solid #ccc;
+    border-top: 3px solid red;
 }
 
 table.schedule td.vacation-day {
@@ -158,7 +159,7 @@ table.schedule th.resource-col,
 table.schedule td.resource-col {
     min-width: 150px;
     width: 150px;
-    border: 3px solid #000;
+    border: 1px solid #ccc;
     font-weight: bold;
 }
 


### PR DESCRIPTION
## Summary
- Destaca las celdas de planificación incompletas con un borde superior rojo
- Sustituye los bordes negros gruesos por bordes estándar en el calendario

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9a458b40c8325b2a6f69613e6f17c