### PR TITLE
Sincronizar filtro del calendario con la Columna 1

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -321,6 +321,10 @@ table.pedidos-calendar th.day-header,
 table.pedidos-calendar td.day-cell {
     width: 180px;
 }
+table.pedidos-calendar td.day-cell.start-day-highlight {
+    border: 3px solid #0b1f4d !important;
+    box-shadow: inset 0 0 0 2px rgba(11, 31, 77, 0.35);
+}
 table.pedidos-calendar th.week-header,
 table.pedidos-calendar td.week-label {
     width: calc(40px / 3);

--- a/templates/calendar_pedidos.html
+++ b/templates/calendar_pedidos.html
@@ -217,6 +217,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const UNSPLIT_URL = "{{ url_for('unsplit_phase') }}";
   const PHASE_HOURS_URL = "{{ url_for('update_phase_hours') }}";
   const OBS_URL_TEMPLATE = "{{ url_for('update_observations', pid='__PID__') }}";
+  const COMPLETE_URL = "{{ url_for('complete') }}";
   const LAST_KEY = 'lastMoved';
   const SCROLL_KEY2 = 'scrollDate';
   const COLUMN_WIDTHS_KEY = 'columna1ColumnWidths';
@@ -230,6 +231,9 @@ document.addEventListener('DOMContentLoaded', () => {
   let splitRemainderInput = null;
   const SPLIT_WORKDAY_HOURS = 8;
   const SPLIT_ORDINAL_WORDS = ['primera', 'segunda', 'tercera', 'cuarta', 'quinta', 'sexta', 'séptima', 'octava', 'novena', 'décima'];
+  const pageParams = new URLSearchParams(window.location.search);
+  const initialFilterValue = pageParams.get('filter');
+  const initialHighlightPid = pageParams.get('highlight');
 
   function escapeHtml(value) {
     if (value === undefined || value === null) return '';
@@ -816,6 +820,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const metaLines = [];
     const clientDate = pickClientDate(info);
     if (clientDate) metaLines.push(`<div>Fecha cliente: ${clientDate}</div>`);
+    const safeProjectAttr = escapeHtml(context.project || info.name || '');
+    const safePidAttr = escapeHtml(context.pid || '');
+    metaLines.push(`<div><button type="button" class="view-calendar-btn" data-project="${safeProjectAttr}" data-pid="${safePidAttr}">Ver calendario</button></div>`);
     if (info.due_date && info.due_date !== '0') metaLines.push(`<div>Límite: ${info.due_date}</div>`);
     if (info.material_confirmed_date && info.material_confirmed_date !== '0') metaLines.push(`<div>Material confirmado: ${info.material_confirmed_date}</div>`);
     if (metaLines.length) html += `<div class="popup-section">${metaLines.join('')}</div>`;
@@ -892,6 +899,23 @@ document.addEventListener('DOMContentLoaded', () => {
     popup.style.left = (anchorRect.left + window.scrollX + 5) + 'px';
     popup.style.top = (anchorRect.bottom + window.scrollY + 5) + 'px';
     popup.style.display = 'block';
+
+    const viewCalendarBtn = popup.querySelector('.view-calendar-btn');
+    if (viewCalendarBtn) {
+      viewCalendarBtn.addEventListener('click', ev => {
+        ev.stopPropagation();
+        try {
+          const url = new URL(COMPLETE_URL, window.location.origin);
+          const projectName = viewCalendarBtn.dataset.project || '';
+          if (projectName) url.searchParams.set('project', projectName);
+          const pidValue = viewCalendarBtn.dataset.pid || '';
+          if (pidValue) url.searchParams.set('highlight', pidValue);
+          window.open(url.toString(), '_blank');
+        } catch (error) {
+          console.error('No se pudo abrir el calendario de planificación:', error);
+        }
+      });
+    }
 
     const del = document.getElementById('del-btn');
     if (del) {
@@ -1182,6 +1206,11 @@ document.addEventListener('DOMContentLoaded', () => {
       row.style.display = show ? '' : 'none';
     });
   });
+
+  if (filterInput && initialFilterValue !== null) {
+    filterInput.value = initialFilterValue;
+    filterInput.dispatchEvent(new Event('input'));
+  }
 
   function parseISODateParts(value) {
     const match = /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/.exec(value || '');
@@ -1582,8 +1611,29 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!pid || !PROJECT_DATA[pid]) return;
       e.stopPropagation();
       const rect = trigger.getBoundingClientRect();
-      openPhasePopup({ pid }, rect);
+      const projectName = row.dataset.project || '';
+      openPhasePopup({ pid, project: projectName }, rect);
     });
+  }
+
+  if (initialHighlightPid) {
+    const highlightRow = Array.from(document.querySelectorAll('.columna-1 .project-row')).find(row => row.dataset.pid === initialHighlightPid);
+    if (highlightRow) {
+      const highlightTitles = Array.from(highlightRow.querySelectorAll('.link-title')).map(link => link.dataset.title).filter(Boolean);
+      if (highlightTitles.length) {
+        toggleHighlight({ titles: highlightTitles });
+      } else {
+        highlightRow.classList.add('highlight');
+      }
+      highlightRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+    const highlightTasks = Array.from(document.querySelectorAll(`.pedidos-calendar .task[data-pid='${initialHighlightPid}']`));
+    if (highlightTasks.length) {
+      highlightTasks[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+    const updatedUrl = new URL(window.location.href);
+    updatedUrl.searchParams.delete('highlight');
+    history.replaceState(null, '', updatedUrl);
   }
 
   const source = new EventSource("{{ url_for('event_stream') }}");

--- a/templates/calendar_pedidos.html
+++ b/templates/calendar_pedidos.html
@@ -906,10 +906,13 @@ document.addEventListener('DOMContentLoaded', () => {
         ev.stopPropagation();
         try {
           const url = new URL(COMPLETE_URL, window.location.origin);
+          const pidValue = viewCalendarBtn.dataset.pid || '';
+          if (pidValue) {
+            url.searchParams.set('project_id', pidValue);
+            url.searchParams.set('highlight', pidValue);
+          }
           const projectName = viewCalendarBtn.dataset.project || '';
           if (projectName) url.searchParams.set('project', projectName);
-          const pidValue = viewCalendarBtn.dataset.pid || '';
-          if (pidValue) url.searchParams.set('highlight', pidValue);
           window.open(url.toString(), '_blank');
         } catch (error) {
           console.error('No se pudo abrir el calendario de planificación:', error);

--- a/templates/calendar_pedidos.html
+++ b/templates/calendar_pedidos.html
@@ -912,7 +912,11 @@ document.addEventListener('DOMContentLoaded', () => {
             url.searchParams.set('highlight', pidValue);
           }
           const projectName = viewCalendarBtn.dataset.project || '';
-          if (projectName) url.searchParams.set('project', projectName);
+          if (projectName) {
+            const ofMatch = projectName.match(/\bOF\s*(\d{4})\b/i);
+            const filterValue = ofMatch ? ofMatch[1] : projectName;
+            url.searchParams.set('project', filterValue);
+          }
           window.open(url.toString(), '_blank');
         } catch (error) {
           console.error('No se pudo abrir el calendario de planificación:', error);

--- a/templates/calendar_pedidos.html
+++ b/templates/calendar_pedidos.html
@@ -229,11 +229,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const splitTotalDisplay = document.getElementById('split-total-hours');
   const splitCancel = document.getElementById('split-cancel');
   let splitRemainderInput = null;
+  let startDayHighlightCell = null;
   const SPLIT_WORKDAY_HOURS = 8;
   const SPLIT_ORDINAL_WORDS = ['primera', 'segunda', 'tercera', 'cuarta', 'quinta', 'sexta', 'séptima', 'octava', 'novena', 'décima'];
   const pageParams = new URLSearchParams(window.location.search);
   const initialFilterValue = pageParams.get('filter');
   const initialHighlightPid = pageParams.get('highlight');
+  const START_DAY_HIGHLIGHT_CLASS = 'start-day-highlight';
 
   function escapeHtml(value) {
     if (value === undefined || value === null) return '';
@@ -663,6 +665,68 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
     return null;
+  }
+
+  function clearStartDayHighlight() {
+    if (startDayHighlightCell && startDayHighlightCell.isConnected) {
+      startDayHighlightCell.classList.remove(START_DAY_HIGHLIGHT_CLASS);
+    }
+    startDayHighlightCell = null;
+  }
+
+  function applyStartDayHighlight(dateValue) {
+    const iso = normalizeDateToIso(dateValue);
+    clearStartDayHighlight();
+    if (!iso) return;
+    const cell = document.querySelector(`.pedidos-calendar td[data-date='${iso}']`);
+    if (cell) {
+      cell.classList.add(START_DAY_HIGHLIGHT_CLASS);
+      startDayHighlightCell = cell;
+    }
+  }
+
+  function resolvePlannedStartByPid(pid) {
+    if (!pid) return '';
+    const candidates = new Set();
+    const startEntry = START_DATA && START_DATA[pid];
+    if (startEntry && typeof startEntry === 'object') {
+      Object.values(startEntry).forEach(value => {
+        const iso = normalizeDateToIso(value);
+        if (iso) candidates.add(iso);
+      });
+    }
+    const info = PROJECT_DATA && PROJECT_DATA[pid];
+    if (info) {
+      ['plan_start', 'montar_start', 'start', 'start_date'].forEach(key => {
+        const iso = normalizeDateToIso(info && info[key]);
+        if (iso) candidates.add(iso);
+      });
+      if (info.segment_starts && typeof info.segment_starts === 'object') {
+        Object.values(info.segment_starts).forEach(value => {
+          const iso = normalizeDateToIso(value);
+          if (iso) candidates.add(iso);
+        });
+      }
+    }
+    if (!candidates.size) return '';
+    return Array.from(candidates).sort()[0];
+  }
+
+  function resolvePlannedStartFromRow(row) {
+    if (!row) return '';
+    const direct = normalizeDateToIso(row.dataset.plan);
+    if (direct) return direct;
+    const pid = resolveRowPid(row);
+    if (!pid) return '';
+    return resolvePlannedStartByPid(pid);
+  }
+
+  function highlightProjectStartByPid(pid) {
+    applyStartDayHighlight(resolvePlannedStartByPid(pid));
+  }
+
+  function highlightProjectStartByRow(row) {
+    applyStartDayHighlight(resolvePlannedStartFromRow(row));
   }
 
   function afterMove(data, originalDate) {
@@ -1238,6 +1302,24 @@ document.addEventListener('DOMContentLoaded', () => {
     return Math.round((laterUtc - earlierUtc) / 86400000);
   }
 
+  function normalizeDateToIso(value) {
+    if (!value) return '';
+    if (value instanceof Date) {
+      return value.toISOString().slice(0, 10);
+    }
+    const text = `${value}`.trim();
+    if (!text) return '';
+    const isoMatch = text.match(/^(\d{4})-(\d{2})-(\d{2})/);
+    if (isoMatch) {
+      return `${isoMatch[1]}-${isoMatch[2]}-${isoMatch[3]}`;
+    }
+    const euroMatch = text.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+    if (euroMatch) {
+      return `${euroMatch[3]}-${euroMatch[2]}-${euroMatch[1]}`;
+    }
+    return '';
+  }
+
   function formatDueDisplay(value) {
     const parts = parseISODateParts(value);
     if (!parts) return '';
@@ -1545,6 +1627,7 @@ document.addEventListener('DOMContentLoaded', () => {
     applyHighlight(null);
     currentHighlightState = null;
     currentHighlightKey = null;
+    clearStartDayHighlight();
   }
 
   function reapplyHighlight() {
@@ -1577,6 +1660,11 @@ document.addEventListener('DOMContentLoaded', () => {
         const title = t.dataset.title;
         if (!title) return;
         toggleHighlight({ titles: [title] });
+        if (currentHighlightState && t.dataset.pid) {
+          highlightProjectStartByPid(t.dataset.pid);
+        } else if (!currentHighlightState) {
+          clearStartDayHighlight();
+        }
       });
     }
     const column = document.querySelector('.columna-1');
@@ -1586,7 +1674,13 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!el) return;
         const title = el.dataset.title;
         if (!title) return;
+        const row = el.closest('.project-row');
         toggleHighlight({ titles: [title] });
+        if (currentHighlightState && row) {
+          highlightProjectStartByRow(row);
+        } else if (!currentHighlightState) {
+          clearStartDayHighlight();
+        }
       });
     }
   }
@@ -1614,6 +1708,7 @@ document.addEventListener('DOMContentLoaded', () => {
           clearHighlight();
         }
       }
+      highlightProjectStartByRow(row);
       const pid = resolveRowPid(row);
       if (!pid || !PROJECT_DATA[pid]) return;
       e.stopPropagation();
@@ -1632,7 +1727,10 @@ document.addEventListener('DOMContentLoaded', () => {
       } else {
         highlightRow.classList.add('highlight');
       }
+      highlightProjectStartByRow(highlightRow);
       highlightRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    } else {
+      highlightProjectStartByPid(initialHighlightPid);
     }
     const highlightTasks = Array.from(document.querySelectorAll(`.pedidos-calendar .task[data-pid='${initialHighlightPid}']`));
     if (highlightTasks.length) {

--- a/templates/calendar_pedidos.html
+++ b/templates/calendar_pedidos.html
@@ -1140,22 +1140,45 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  function normalizeFilterValue(value) {
+    return (value === undefined || value === null) ? '' : `${value}`.toLowerCase();
+  }
+
+  function elementTextIncludes(element, query) {
+    if (!query) return true;
+    if (!element) return false;
+    return element.textContent.toLowerCase().includes(query);
+  }
+
   const filterInput = document.getElementById('filter-input');
   filterInput.addEventListener('input', () => {
-    const q = filterInput.value.toLowerCase();
+    const q = normalizeFilterValue(filterInput.value.trim());
     document.querySelectorAll('.pedidos-calendar .task').forEach(t => {
-      const proj = (t.dataset.project || '').toLowerCase();
-      const cli = (t.dataset.client || '').toLowerCase();
-      const code = (t.dataset.code || '').toLowerCase();
-      t.style.display = (!q || proj.includes(q) || cli.includes(q) || code.includes(q)) ? '' : 'none';
+      const proj = normalizeFilterValue(t.dataset.project);
+      const cli = normalizeFilterValue(t.dataset.client);
+      const code = normalizeFilterValue(t.dataset.code);
+      const text = normalizeFilterValue(t.textContent);
+      const showTask = !q || proj.includes(q) || cli.includes(q) || code.includes(q) || text.includes(q);
+      t.style.display = showTask ? '' : 'none';
     });
     document.querySelectorAll('.columna-1 .project-row').forEach(row => {
-      const proj = (row.dataset.project || '').toLowerCase();
-      const title = (row.dataset.title || '').toLowerCase();
-      const cli = (row.dataset.client || '').toLowerCase();
-      const display = (row.dataset.display || '').toLowerCase();
-      const code = (row.dataset.code || '').toLowerCase();
-      const show = (!q || proj.includes(q) || cli.includes(q) || title.includes(q) || display.includes(q) || code.includes(q));
+      const proj = normalizeFilterValue(row.dataset.project);
+      const title = normalizeFilterValue(row.dataset.title);
+      const cli = normalizeFilterValue(row.dataset.client);
+      const display = normalizeFilterValue(row.dataset.display);
+      const code = normalizeFilterValue(row.dataset.code);
+      const rowTextMatches = elementTextIncludes(row, q);
+      let linkMatches = false;
+      if (q) {
+        linkMatches = Array.from(row.querySelectorAll('.link-title')).some(link => {
+          const linkTitle = normalizeFilterValue(link.dataset.title);
+          const linkLane = normalizeFilterValue(link.dataset.lane);
+          const linkColumn = normalizeFilterValue(link.dataset.column);
+          const linkText = normalizeFilterValue(link.textContent);
+          return linkTitle.includes(q) || linkLane.includes(q) || linkColumn.includes(q) || linkText.includes(q);
+        });
+      }
+      const show = !q || proj.includes(q) || cli.includes(q) || title.includes(q) || display.includes(q) || code.includes(q) || rowTextMatches || linkMatches;
       row.style.display = show ? '' : 'none';
     });
   });

--- a/templates/complete.html
+++ b/templates/complete.html
@@ -84,6 +84,7 @@
         <h2>Calendario</h2>
         <div class="controls">
             <form id="filter-form" method="get">
+                <input type="hidden" name="project_id" value="{{ project_id_filter }}">
                 <label>Proyecto: <input type="text" name="project" value="{{ project_filter }}"></label>
                 <label>Cliente: <input type="text" name="client" value="{{ client_filter }}"></label>
                 <button type="submit">Filtrar</button>
@@ -1105,6 +1106,13 @@
   const PROJECT_FILTER = {{ project_filter|tojson }};
   const CLIENT_FILTER = {{ client_filter|tojson }};
   const FILTER_ACTIVE = {{ filter_active|tojson }};
+  const projectFilterInput = filterForm ? filterForm.querySelector('input[name="project"]') : null;
+  const projectIdField = filterForm ? filterForm.querySelector('input[name="project_id"]') : null;
+  if (projectFilterInput && projectIdField) {
+    projectFilterInput.addEventListener('input', () => {
+      projectIdField.value = '';
+    });
+  }
 
   function makeDraggable(el) {
     let startX, startY, startLeft, startTop;

--- a/templates/complete.html
+++ b/templates/complete.html
@@ -479,6 +479,7 @@
   const PROJ_START_URL = "{{ url_for('update_start_date') }}";
   const SPLIT_URL = "{{ url_for('split_phase_route') }}";
   const UNSPLIT_URL = "{{ url_for('unsplit_phase') }}";
+  const REMOVE_ARCHIVED_URL = "{{ url_for('remove_archived_phase') }}";
   const HOURS_URL = "{{ url_for('update_hours') }}";
   const PHASE_HOURS_URL = "{{ url_for('update_phase_hours') }}";
   const ROW_URL = "{{ url_for('update_project_row') }}";
@@ -1467,6 +1468,11 @@ let draggedTaskElement = null;
           </div>
         `);
       } else {
+        const kanbanColumn = ((info && info.kanban_column) || '').toString().trim().toLowerCase();
+        if (kanbanColumn === 'ready to archive') {
+          const archivePartAttr = normalizedPart ? ` data-part="${normalizedPart}"` : '';
+          actionLines.push(`<div><button type="button" class="remove-archived-phase-btn" data-pid="${t.dataset.pid}" data-phase="${t.dataset.phase}"${archivePartAttr}>Eliminar fase archivada</button></div>`);
+        }
         if (info && info.observations) {
           const safeObsValue = escapeHtml(`${info.observations}`);
           actionLines.push(`<div class="popup-section"><strong>Observaciones</strong><div>${safeObsValue}</div></div>`);
@@ -1516,6 +1522,55 @@ let draggedTaskElement = null;
           } catch (error) {
             console.error('No se pudo abrir Calendario pedidos:', error);
           }
+        });
+      }
+      const removeArchivedBtn = popup.querySelector('.remove-archived-phase-btn');
+      if (removeArchivedBtn) {
+        removeArchivedBtn.addEventListener('click', ev => {
+          ev.stopPropagation();
+          if (!confirm('¿Eliminar esta fase archivada del calendario?')) return;
+          const payload = { pid: removeArchivedBtn.dataset.pid, phase: removeArchivedBtn.dataset.phase };
+          fetch(REMOVE_ARCHIVED_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'same-origin',
+            body: JSON.stringify(payload)
+          })
+            .then(resp => resp.json().then(data => ({ ok: resp.ok, data })).catch(() => ({ ok: resp.ok, data: {} })))
+            .then(({ ok, data }) => {
+              if (!ok) {
+                throw new Error(data.error || 'Error eliminando fase archivada');
+              }
+              const targetPid = removeArchivedBtn.dataset.pid;
+              const targetPhase = removeArchivedBtn.dataset.phase;
+              document.querySelectorAll('.task').forEach(taskEl => {
+                if (taskEl.dataset.pid === targetPid && taskEl.dataset.phase === targetPhase && taskEl.dataset.archived === 'true') {
+                  taskEl.remove();
+                }
+              });
+              const projectInfo = PROJECT_DATA[targetPid];
+              if (projectInfo && typeof projectInfo === 'object') {
+                if (projectInfo.phases && Object.prototype.hasOwnProperty.call(projectInfo.phases, targetPhase)) {
+                  delete projectInfo.phases[targetPhase];
+                }
+                if (projectInfo.assigned && Object.prototype.hasOwnProperty.call(projectInfo.assigned, targetPhase)) {
+                  delete projectInfo.assigned[targetPhase];
+                }
+                if (projectInfo.auto_hours && Object.prototype.hasOwnProperty.call(projectInfo.auto_hours, targetPhase)) {
+                  delete projectInfo.auto_hours[targetPhase];
+                }
+                if (Array.isArray(projectInfo.phase_sequence)) {
+                  projectInfo.phase_sequence = projectInfo.phase_sequence.filter(item => item !== targetPhase);
+                }
+                if (Array.isArray(projectInfo.frozen_tasks)) {
+                  projectInfo.frozen_tasks = projectInfo.frozen_tasks.filter(item => item && item.phase !== targetPhase);
+                }
+              }
+              popup.style.display = 'none';
+            })
+            .catch(err => {
+              alert(err.message || 'Error eliminando fase archivada');
+            });
         });
       }
       const del = document.getElementById('del-btn');

--- a/templates/complete.html
+++ b/templates/complete.html
@@ -484,6 +484,7 @@
   const WORKER_NOTE_URL = "{{ url_for('update_worker_note') }}";
   const OBS_URL_TEMPLATE = "{{ url_for('update_observations', pid='__PID__') }}";
   const MANUAL_REORDER_URL = "{{ url_for('manual_bucket_reorder_route') }}";
+  const CALENDAR_PEDIDOS_URL = "{{ url_for('calendar_pedidos') }}";
   const HISTORY_URL = "{{ url_for('phase_history') }}";
   const ASSIGN_VACATION_DAY_URL = "{{ url_for('assign_vacation_day') }}";
   const UPDATE_WORKER_DAY_HOURS_URL = "{{ url_for('update_worker_day_hours') }}";
@@ -1350,15 +1351,37 @@ let draggedTaskElement = null;
       if (metaLines.length) html += `<div class="popup-section">${metaLines.join('')}</div>`;
       const kanbanFields = info.kanban_display_fields || {};
       const kanbanEntries = Object.entries(kanbanFields).filter(([, value]) => value !== null && value !== undefined && `${value}`.trim() !== '');
+      let addedPedidosButton = false;
       if (kanbanEntries.length) {
         let kanbanHtml = '<div class="popup-section kanban-extra-fields">';
         kanbanEntries.forEach(([label, value]) => {
           const displayValue = `${value}`;
           kanbanHtml += `<div>${label}: ${displayValue}</div>`;
-          });
-          kanbanHtml += '</div>';
-          html += kanbanHtml;
+          if (!addedPedidosButton) {
+            const normalizedLabel = (label || '').toString().trim().toLowerCase();
+            if (normalizedLabel === 'estado pedidos' || normalizedLabel === 'estado de los pedidos') {
+              const safeProjectAttr = escapeHtml(info.name || t.dataset.project || '');
+              const safePidAttr = escapeHtml(t.dataset.pid || '');
+              kanbanHtml += `<div><button type="button" class="view-pedidos-btn" data-project="${safeProjectAttr}" data-pid="${safePidAttr}">Ver pedidos</button></div>`;
+              addedPedidosButton = true;
+            }
+          }
+        });
+        if (!addedPedidosButton) {
+          const safeProjectAttr = escapeHtml(info.name || t.dataset.project || '');
+          const safePidAttr = escapeHtml(t.dataset.pid || '');
+          kanbanHtml += `<div><button type="button" class="view-pedidos-btn" data-project="${safeProjectAttr}" data-pid="${safePidAttr}">Ver pedidos</button></div>`;
+          addedPedidosButton = true;
         }
+        kanbanHtml += '</div>';
+        html += kanbanHtml;
+      }
+      if (!addedPedidosButton) {
+        const safeProjectAttr = escapeHtml(info.name || t.dataset.project || '');
+        const safePidAttr = escapeHtml(t.dataset.pid || '');
+        html += `<div class="popup-section kanban-extra-fields"><div><button type="button" class="view-pedidos-btn" data-project="${safeProjectAttr}" data-pid="${safePidAttr}">Ver pedidos</button></div></div>`;
+        addedPedidosButton = true;
+      }
       const projectPhases = info.phases || {};
       const assignedMap = info.assigned || {};
       const phaseLines = [];
@@ -1464,11 +1487,27 @@ let draggedTaskElement = null;
       popup.style.top = (rect.bottom + window.scrollY + 5) + 'px';
       popup.style.display = 'block';
       const historyBtn = popup.querySelector('.history-btn');
+      const viewPedidosBtn = popup.querySelector('.view-pedidos-btn');
       if (historyBtn) {
         historyBtn.addEventListener('click', ev => {
           ev.stopPropagation();
           const partValue = normalizePartValue(historyBtn.dataset.part);
           openHistory(historyBtn.dataset.pid, historyBtn.dataset.phase, partValue, displayName, displayClient);
+        });
+      }
+      if (viewPedidosBtn) {
+        viewPedidosBtn.addEventListener('click', ev => {
+          ev.stopPropagation();
+          try {
+            const url = new URL(CALENDAR_PEDIDOS_URL, window.location.origin);
+            const projectName = viewPedidosBtn.dataset.project || '';
+            if (projectName) url.searchParams.set('filter', projectName);
+            const pidValue = viewPedidosBtn.dataset.pid || '';
+            if (pidValue) url.searchParams.set('highlight', pidValue);
+            window.open(url.toString(), '_blank');
+          } catch (error) {
+            console.error('No se pudo abrir Calendario pedidos:', error);
+          }
         });
       }
       const del = document.getElementById('del-btn');

--- a/templates/index.html
+++ b/templates/index.html
@@ -356,6 +356,7 @@
   const PHASE_HOURS_URL = "{{ url_for('update_phase_hours') }}";
   const WORKER_NOTE_URL = "{{ url_for('update_worker_note') }}";
   const PROJECT_LINKS_URL = "{{ url_for('project_links_api') }}";
+  const CALENDAR_PEDIDOS_URL = "{{ url_for('calendar_pedidos') }}";
   const OBS_URL_TEMPLATE = "{{ url_for('update_observations', pid='__PID__') }}";
   const MANUAL_REORDER_URL = "{{ url_for('manual_bucket_reorder_route') }}";
   const HISTORY_URL = "{{ url_for('phase_history') }}";
@@ -1444,14 +1445,36 @@ let draggedTaskElement = null;
       if (metaLines.length) html += `<div class="popup-section">${metaLines.join('')}</div>`;
       const kanbanFields = info.kanban_display_fields || {};
       const kanbanEntries = Object.entries(kanbanFields).filter(([, value]) => value !== null && value !== undefined && `${value}`.trim() !== '');
+      let addedPedidosButton = false;
       if (kanbanEntries.length) {
         let kanbanHtml = '<div class="popup-section kanban-extra-fields">';
         kanbanEntries.forEach(([label, value]) => {
           const displayValue = `${value}`;
           kanbanHtml += `<div>${label}: ${displayValue}</div>`;
+          if (!addedPedidosButton) {
+            const normalizedLabel = (label || '').toString().trim().toLowerCase();
+            if (normalizedLabel === 'estado pedidos' || normalizedLabel === 'estado de los pedidos') {
+              const safeProjectAttr = escapeHtml(info.name || t.dataset.project || '');
+              const safePidAttr = escapeHtml(t.dataset.pid || '');
+              kanbanHtml += `<div><button type="button" class="view-pedidos-btn" data-project="${safeProjectAttr}" data-pid="${safePidAttr}">Ver pedidos</button></div>`;
+              addedPedidosButton = true;
+            }
+          }
         });
+        if (!addedPedidosButton) {
+          const safeProjectAttr = escapeHtml(info.name || t.dataset.project || '');
+          const safePidAttr = escapeHtml(t.dataset.pid || '');
+          kanbanHtml += `<div><button type="button" class="view-pedidos-btn" data-project="${safeProjectAttr}" data-pid="${safePidAttr}">Ver pedidos</button></div>`;
+          addedPedidosButton = true;
+        }
         kanbanHtml += '</div>';
         html += kanbanHtml;
+      }
+      if (!addedPedidosButton) {
+        const safeProjectAttr = escapeHtml(info.name || t.dataset.project || '');
+        const safePidAttr = escapeHtml(t.dataset.pid || '');
+        html += `<div class="popup-section kanban-extra-fields"><div><button type="button" class="view-pedidos-btn" data-project="${safeProjectAttr}" data-pid="${safePidAttr}">Ver pedidos</button></div></div>`;
+        addedPedidosButton = true;
       }
       const previousPhases = Array.isArray(info.kanban_previous_phases)
         ? new Set(info.kanban_previous_phases)
@@ -1562,11 +1585,27 @@ let draggedTaskElement = null;
       popup.style.top = (rect.bottom + window.scrollY + 5) + 'px';
       popup.style.display = 'block';
       const historyBtn = popup.querySelector('.history-btn');
+      const viewPedidosBtn = popup.querySelector('.view-pedidos-btn');
       if (historyBtn) {
         historyBtn.addEventListener('click', ev => {
           ev.stopPropagation();
           const partValue = normalizePartValue(historyBtn.dataset.part);
           openHistory(historyBtn.dataset.pid, historyBtn.dataset.phase, partValue, displayName, displayClient);
+        });
+      }
+      if (viewPedidosBtn) {
+        viewPedidosBtn.addEventListener('click', ev => {
+          ev.stopPropagation();
+          try {
+            const url = new URL(CALENDAR_PEDIDOS_URL, window.location.origin);
+            const projectName = viewPedidosBtn.dataset.project || '';
+            if (projectName) url.searchParams.set('filter', projectName);
+            const pidValue = viewPedidosBtn.dataset.pid || '';
+            if (pidValue) url.searchParams.set('highlight', pidValue);
+            window.open(url.toString(), '_blank');
+          } catch (error) {
+            console.error('No se pudo abrir Calendario pedidos:', error);
+          }
         });
       }
       const del = document.getElementById('del-btn');


### PR DESCRIPTION
## Summary
- normalise filter comparisons for tasks and columna 1 rows in the calendario de pedidos
- include texto de fila y detalles de fases para que la columna 1 responda al filtro del calendario

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69036b46d8d08325ac205813ee464700