### PR TITLE
Ensure archived phase removal frees scheduled capacity

### DIFF
--- a/app.py
+++ b/app.py
@@ -3517,6 +3517,12 @@ def calendar_view():
         material_status_map[str(archived_pid)] = 'archived'
         material_missing_map.setdefault(str(archived_pid), [])
 
+    for row in filtered_projects:
+        pid = row.get('id')
+        if pid is None:
+            continue
+        row['material_status'] = material_status_map.get(str(pid), 'complete')
+
     manual_index = {}
     manual_bucket_items = []
     if manual_entries:
@@ -4837,7 +4843,18 @@ def project_list():
         projects.sort(key=lambda p: orig_order[p['id']], reverse=True)
     start_map = phase_start_map(projects)
     hours_map = load_daily_hours()
+    material_status_map, _ = compute_material_status_map(projects)
+    for proj in projects:
+        pid = proj.get('id')
+        if pid is None:
+            continue
+        proj['material_status'] = material_status_map.get(str(pid), 'complete')
     projects = expand_for_display(projects)
+    for proj in projects:
+        pid = proj.get('id')
+        if pid is None:
+            continue
+        proj['material_status'] = material_status_map.get(str(pid), 'complete')
     return render_template(
         'projects.html',
         projects=projects,
@@ -4849,6 +4866,7 @@ def project_list():
         start_map=start_map,
         hours=hours_map,
         palette=COLORS,
+        material_status_labels=MATERIAL_STATUS_LABELS,
     )
 
 
@@ -5623,6 +5641,11 @@ def complete():
         project_map[pid] = info
         project_map[str(pid)] = info
     start_map = phase_start_map(projects)
+    for row in filtered_projects:
+        pid = row.get('id')
+        if pid is None:
+            continue
+        row['material_status'] = material_status_map.get(str(pid), 'complete')
     if project_id_filter and not project_filter:
         info = project_map.get(project_id_filter)
         if info:

--- a/schedule.py
+++ b/schedule.py
@@ -1163,10 +1163,7 @@ def assign_phase(
             if day_limit is not None:
                 limit = min(limit, day_limit)
         if override_limit is not None:
-            if limit == float('inf'):
-                limit = override_limit
-            else:
-                limit = min(limit, override_limit)
+            limit = override_limit
 
         if phase in ('tratamiento', 'mecanizar'):
             start = 0

--- a/static/style.css
+++ b/static/style.css
@@ -60,10 +60,6 @@ table.schedule td.weekend-cell {
 .phase-entry.phase-previous {
     background-color: #e6e6e6;
 }
-.projects-table td.plan-col span {
-    font-size: 3em;
-    line-height: 1;
-}
 .split-dot {
     font-weight: bold;
     margin-right: 2px;

--- a/static/style.css
+++ b/static/style.css
@@ -629,6 +629,25 @@ tr.collapsed td:not(:first-child) { display: none; }
     background: #fff;
     z-index: 10;
 }
+.projects-table thead th.sortable {
+    cursor: pointer;
+}
+.projects-table thead th.sorted-asc::after,
+.projects-table thead th.sorted-desc::after {
+    content: '';
+    display: inline-block;
+    margin-left: 6px;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+}
+.projects-table thead th.sorted-asc::after {
+    border-bottom: 7px solid #333;
+    transform: translateY(-2px);
+}
+.projects-table thead th.sorted-desc::after {
+    border-top: 7px solid #333;
+    transform: translateY(2px);
+}
 
 .project-form {
     border-collapse: collapse;

--- a/static/style.css
+++ b/static/style.css
@@ -629,28 +629,34 @@ tr.collapsed td:not(:first-child) { display: none; }
 .schedule thead.open .notes-row th { top: 30px; }
 .schedule thead.open .day-row th { top: 60px; }
 
-.projects-table thead th {
+.projects-table thead th,
+.columna-1-table thead th {
     position: sticky;
     top: 0;
     background: #fff;
     z-index: 10;
 }
-.projects-table thead th.sortable {
+.projects-table thead th.sortable,
+.columna-1-table thead th.sortable {
     cursor: pointer;
 }
 .projects-table thead th.sorted-asc::after,
-.projects-table thead th.sorted-desc::after {
+.projects-table thead th.sorted-desc::after,
+.columna-1-table thead th.sorted-asc::after,
+.columna-1-table thead th.sorted-desc::after {
     content: '';
     display: inline-block;
     margin-left: 6px;
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
 }
-.projects-table thead th.sorted-asc::after {
+.projects-table thead th.sorted-asc::after,
+.columna-1-table thead th.sorted-asc::after {
     border-bottom: 7px solid #333;
     transform: translateY(-2px);
 }
-.projects-table thead th.sorted-desc::after {
+.projects-table thead th.sorted-desc::after,
+.columna-1-table thead th.sorted-desc::after {
     border-top: 7px solid #333;
     transform: translateY(2px);
 }

--- a/static/style.css
+++ b/static/style.css
@@ -211,6 +211,12 @@ table.schedule td.weekend-cell {
 
 .calendar-flex { display: flex; align-items: flex-start; position: relative; width: 100%; }
 .schedule-wrapper { flex: 1; overflow-x: auto; }
+
+.schedule-wrapper.dragging,
+.schedule-wrapper.dragging * {
+  cursor: grabbing !important;
+  user-select: none;
+}
 .unplanned-panel {
     width: 2500px;
     border-left: 1px solid #ccc;

--- a/static/style.css
+++ b/static/style.css
@@ -43,6 +43,43 @@ table.schedule td.weekend-cell {
 .due-before { color: #e6b800; }
 .due-after { color: red; }
 
+.quick-card-form {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: flex-end;
+    margin-bottom: 12px;
+}
+.quick-card-form label {
+    font-weight: 600;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+.quick-card-form label span {
+    font-size: 0.85rem;
+}
+.quick-card-form input[type="date"],
+.quick-card-form input[type="text"] {
+    padding: 4px 8px;
+    border: 1px solid #b3b3b3;
+    border-radius: 4px;
+    min-height: 32px;
+}
+.quick-card-form button {
+    padding: 6px 14px;
+    border: none;
+    border-radius: 4px;
+    background: #2b3a67;
+    color: #fff;
+    font-weight: 600;
+    cursor: pointer;
+}
+.quick-card-form button:hover,
+.quick-card-form button:focus {
+    background: #1f2a49;
+}
+
 .phase-deadline-indicator {
   margin-right: 2px;
   font-weight: bold;
@@ -64,12 +101,17 @@ table.schedule td.weekend-cell {
     font-weight: bold;
     margin-right: 2px;
 }
-.task {
+.task { 
     margin-bottom: 2px;
     cursor: grab;
     display: flex;
     border: 3px solid transparent;
     background: #fff;
+}
+.task.quick-card {
+    background: #f5f5f5;
+    border-color: #000;
+    color: #000;
 }
 .task.frozen {
     background: var(--frozen-background, rgba(204, 229, 255, 0.45));

--- a/templates/base.html
+++ b/templates/base.html
@@ -34,13 +34,10 @@
 <body>
     <nav>
         <a href="{{ url_for('complete') }}">Completo</a> |
-        <a href="{{ url_for('calendar_view') }}">Calendario</a> |
         <a href="{{ url_for('calendar_pedidos') }}">Calendario pedidos</a> |
         <a href="{{ url_for('orden_carpetas_view') }}">Orden carpetas</a> |
         <a href="{{ url_for('gantt_view') }}">Gantt</a> |
         <a href="{{ url_for('gantt_orders_view') }}">Gantt pedidos</a> |
-        <a href="{{ url_for('cronologico_view') }}">Cronológico</a> |
-        <a href="{{ url_for('project_list') }}">Proyectos</a> |
         <a href="{{ url_for('note_list') }}">Notas</a> |
         <a href="{{ url_for('observation_list') }}">Observaciones</a> |
         <a href="{{ url_for('vacation_list') }}">Vacaciones</a> |

--- a/templates/calendar_pedidos.html
+++ b/templates/calendar_pedidos.html
@@ -114,7 +114,7 @@
               data-code="{{ code_value }}"
               data-due="{{ item.due or '' }}"
               data-plan="{{ plan_value or '' }}">
-            <td class="proj-title-cell">
+            <td class="proj-title-cell" data-sort="{{ (title_value or project_value)|default('', true)|lower }}">
               {% if code_value %}
               <span class="proj-code proj-code-badge"
                     data-project="{{ project_value }}"
@@ -124,17 +124,36 @@
                       data-project="{{ project_value }}"
                       data-code="{{ code_value }}">{{ title_value or project_value }}</strong>
             </td>
-            <td class="due-cell">
+            <td class="due-cell" data-sort="{{ item.due or '' }}" data-sort-type="date">
             {% if due_display %}
               <span class="proj-due">{{ due_display }}</span>
             {% endif %}
             </td>
-            <td class="start-cell">
+            <td class="start-cell" data-sort="{{ plan_value or '' }}" data-sort-type="date">
             {% if start_display %}
               <span class="proj-start">{{ start_display }}</span>
             {% endif %}
             </td>
-            <td class="order-date-cell">
+            {% set order_meta = namespace(first=None) %}
+            {% set count_meta = namespace(value=None) %}
+            {% set link_meta = namespace(value=None) %}
+            {% for link in item.links %}
+                {% set detail = details[loop.index0] if loop.index0 < details|length else {} %}
+                {% set order_value = detail.order_date %}
+                {% if order_value %}
+                    {% if order_meta.first is none or order_value < order_meta.first %}
+                        {% set order_meta.first = order_value %}
+                    {% endif %}
+                {% endif %}
+                {% set order_days = detail.order_days %}
+                {% if order_days is not none and count_meta.value is none %}
+                    {% set count_meta.value = order_days %}
+                {% endif %}
+                {% if link_meta.value is none and link %}
+                    {% set link_meta.value = link|lower %}
+                {% endif %}
+            {% endfor %}
+            <td class="order-date-cell" data-sort="{{ order_meta.first or '' }}" data-sort-type="date">
             {% for link in item.links %}
                 {% set detail = details[loop.index0] if loop.index0 < details|length else {} %}
                 {% set order_value = detail.order_date %}
@@ -151,7 +170,7 @@
               </div>
             {% endfor %}
             </td>
-            <td class="order-count-cell">
+            <td class="order-count-cell" data-sort="{{ count_meta.value if count_meta.value is not none else '' }}" data-sort-type="number">
             {% for link in item.links %}
                 {% set detail = details[loop.index0] if loop.index0 < details|length else {} %}
                 {% set order_days = detail.order_days %}
@@ -165,7 +184,7 @@
               </div>
             {% endfor %}
             </td>
-            <td class="links-cell">
+            <td class="links-cell" data-sort="{{ link_meta.value or '' }}">
             {% for link in item.links %}
                 {% set detail = details[loop.index0] if loop.index0 < details|length else {} %}
                 {% set column_value = detail.column|default('', true) %}
@@ -215,6 +234,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const START_URL = "{{ url_for('update_phase_start') }}";
   const SPLIT_URL = "{{ url_for('split_phase_route') }}";
   const UNSPLIT_URL = "{{ url_for('unsplit_phase') }}";
+  const TABLE_COLLATOR = typeof Intl !== 'undefined'
+    ? new Intl.Collator('es', { sensitivity: 'base', numeric: true })
+    : null;
   const PHASE_HOURS_URL = "{{ url_for('update_phase_hours') }}";
   const OBS_URL_TEMPLATE = "{{ url_for('update_observations', pid='__PID__') }}";
   const COMPLETE_URL = "{{ url_for('complete') }}";
@@ -236,6 +258,113 @@ document.addEventListener('DOMContentLoaded', () => {
   const initialFilterValue = pageParams.get('filter');
   const initialHighlightPid = pageParams.get('highlight');
   const START_DAY_HIGHLIGHT_CLASS = 'start-day-highlight';
+
+  function parseSortableCell(cell) {
+    if (!cell) {
+      return { blank: true, value: '', type: 'text' };
+    }
+    const raw = cell.dataset.sort !== undefined ? cell.dataset.sort : cell.textContent.trim();
+    const type = cell.dataset.sortType || 'text';
+    const rawString = raw === undefined || raw === null ? '' : `${raw}`;
+    const isBlank = rawString.trim() === '';
+    if (type === 'number') {
+      const num = Number(rawString);
+      return { blank: isBlank, value: Number.isNaN(num) ? 0 : num, type };
+    }
+    if (type === 'date') {
+      if (isBlank) {
+        return { blank: true, value: 0, type };
+      }
+      let time = Number.NaN;
+      if (/^\d{4}-\d{2}-\d{2}$/.test(rawString)) {
+        time = Date.parse(rawString);
+      } else if (/^\d{1,2}\/\d{1,2}\/\d{4}$/.test(rawString)) {
+        const [day, month, year] = rawString.split('/').map(Number);
+        if (!Number.isNaN(day) && !Number.isNaN(month) && !Number.isNaN(year)) {
+          time = Date.UTC(year, month - 1, day);
+        }
+      } else {
+        time = Date.parse(rawString);
+      }
+      if (Number.isNaN(time)) {
+        return { blank: true, value: 0, type };
+      }
+      return { blank: false, value: time, type };
+    }
+    return { blank: isBlank, value: rawString.toLowerCase(), type: 'text' };
+  }
+
+  function applyColumna1Sort(table, th, order) {
+    if (!table || !th) return;
+    const tbody = table.tBodies[0];
+    if (!tbody) return;
+    const headers = Array.from(table.querySelectorAll('thead th'));
+    const index = headers.indexOf(th);
+    if (index === -1) return;
+    const rows = Array.from(tbody.querySelectorAll('tr'));
+    rows.sort((a, b) => {
+      const aCell = a.children[index];
+      const bCell = b.children[index];
+      const aVal = parseSortableCell(aCell);
+      const bVal = parseSortableCell(bCell);
+      if (aVal.blank && bVal.blank) return 0;
+      if (aVal.blank !== bVal.blank) {
+        return aVal.blank ? 1 : -1;
+      }
+      let comparison = 0;
+      if (aVal.type === 'number' && bVal.type === 'number') {
+        comparison = aVal.value - bVal.value;
+      } else if (aVal.type === 'date' && bVal.type === 'date') {
+        comparison = aVal.value - bVal.value;
+      } else if (TABLE_COLLATOR) {
+        comparison = TABLE_COLLATOR.compare(aVal.value, bVal.value);
+      } else {
+        comparison = aVal.value < bVal.value ? -1 : aVal.value > bVal.value ? 1 : 0;
+      }
+      if (comparison === 0) return 0;
+      return order === 'asc' ? (comparison < 0 ? -1 : 1) : (comparison < 0 ? 1 : -1);
+    });
+    rows.forEach((row) => tbody.appendChild(row));
+  }
+
+  function updateColumna1HeaderState(headers, active, order) {
+    headers.forEach((header) => {
+      if (header === active) {
+        header.dataset.sortOrder = order;
+        header.classList.toggle('sorted-asc', order === 'asc');
+        header.classList.toggle('sorted-desc', order === 'desc');
+      } else {
+        header.dataset.sortOrder = '';
+        header.classList.remove('sorted-asc', 'sorted-desc');
+      }
+    });
+  }
+
+  function reapplyColumna1Sort(table) {
+    if (!table) return;
+    const active = table.querySelector('thead th.sorted-asc, thead th.sorted-desc');
+    if (!active) return;
+    const order = active.dataset.sortOrder || (active.classList.contains('sorted-desc') ? 'desc' : 'asc');
+    applyColumna1Sort(table, active, order || 'asc');
+  }
+
+  function initColumna1Sorting(root = document) {
+    root.querySelectorAll('.columna-1-table').forEach((table) => {
+      const tbody = table.tBodies[0];
+      if (!tbody) return;
+      const headers = Array.from(table.querySelectorAll('thead th'));
+      headers.forEach((th, index) => {
+        if (th.dataset.sortableInit === '1') return;
+        th.dataset.sortableInit = '1';
+        th.classList.add('sortable');
+        th.addEventListener('click', () => {
+          const order = th.dataset.sortOrder === 'asc' ? 'desc' : 'asc';
+          updateColumna1HeaderState(headers, th, order);
+          applyColumna1Sort(table, th, order);
+        });
+      });
+    });
+  }
 
   function escapeHtml(value) {
     if (value === undefined || value === null) return '';
@@ -1687,6 +1816,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   attachHighlightHandlers();
   updateDueWarnings();
+  initColumna1Sorting();
   initColumnResizing();
 
   const projectList = document.querySelector('.columna-1');
@@ -1784,6 +1914,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
           const titleCell = document.createElement('td');
           titleCell.className = 'proj-title-cell';
+          const titleSortValue = (resolvedTitle || projectValue || '').toLocaleLowerCase('es-ES');
+          titleCell.dataset.sort = titleSortValue;
           if (code) {
             const codeSpan = document.createElement('span');
             codeSpan.className = 'proj-code proj-code-badge';
@@ -1802,6 +1934,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
           const dueCell = document.createElement('td');
           dueCell.className = 'due-cell';
+          dueCell.dataset.sortType = 'date';
+          dueCell.dataset.sort = item.due ? String(item.due).trim() : '';
           if (dueDisplay) {
             const dueSpan = document.createElement('span');
             dueSpan.className = 'proj-due';
@@ -1812,6 +1946,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
           const startCell = document.createElement('td');
           startCell.className = 'start-cell';
+          startCell.dataset.sortType = 'date';
+          startCell.dataset.sort = planValue;
           if (startDisplay) {
             const startSpan = document.createElement('span');
             startSpan.className = 'proj-start';
@@ -1822,14 +1958,20 @@ document.addEventListener('DOMContentLoaded', () => {
 
           const orderCell = document.createElement('td');
           orderCell.className = 'order-date-cell';
+          orderCell.dataset.sortType = 'date';
 
           const countCell = document.createElement('td');
           countCell.className = 'order-count-cell';
+          countCell.dataset.sortType = 'number';
 
           const linksCell = document.createElement('td');
           linksCell.className = 'links-cell';
+          linksCell.dataset.sort = '';
           const linkDetails = Array.isArray(item.link_details) ? item.link_details : [];
           const links = Array.isArray(item.links) ? item.links : [];
+          let earliestOrder = '';
+          let firstCount = '';
+          let firstLinkSort = '';
           links.forEach((link, idx) => {
             const detail = linkDetails[idx] || {};
             const orderDiv = document.createElement('div');
@@ -1840,6 +1982,9 @@ document.addEventListener('DOMContentLoaded', () => {
               orderDiv.dataset.order = orderValue;
               orderDiv.textContent = formatDueDisplay(orderValue);
               if (!orderDiv.textContent) orderDiv.textContent = orderValue;
+              if (!earliestOrder || orderValue < earliestOrder) {
+                earliestOrder = orderValue;
+              }
             } else if (orderRaw) {
               orderDiv.textContent = orderRaw;
             } else {
@@ -1854,6 +1999,9 @@ document.addEventListener('DOMContentLoaded', () => {
             if (Number.isFinite(daysNumber)) {
               countDiv.dataset.days = `${daysNumber}`;
               countDiv.textContent = `${daysNumber}`;
+              if (!firstCount) {
+                firstCount = `${daysNumber}`;
+              }
             } else {
               countDiv.appendChild(document.createTextNode('\u00a0'));
             }
@@ -1874,8 +2022,14 @@ document.addEventListener('DOMContentLoaded', () => {
             linkDiv.dataset.column = columnValue;
             if (tooltip) linkDiv.title = tooltip;
             linkDiv.textContent = link;
+            if (!firstLinkSort && link) {
+              firstLinkSort = link.toLocaleLowerCase('es-ES');
+            }
             linksCell.appendChild(linkDiv);
           });
+          orderCell.dataset.sort = earliestOrder;
+          countCell.dataset.sort = firstCount;
+          linksCell.dataset.sort = firstLinkSort;
           row.appendChild(orderCell);
           row.appendChild(countCell);
           row.appendChild(linksCell);
@@ -1883,6 +2037,8 @@ document.addEventListener('DOMContentLoaded', () => {
           resolveRowPid(row);
           container.appendChild(row);
         });
+        const columnaTable = document.querySelector('.columna-1-table');
+        reapplyColumna1Sort(columnaTable);
         filterInput.dispatchEvent(new Event('input'));
         reapplyHighlight();
         updateDueWarnings();

--- a/templates/calendar_pedidos.html
+++ b/templates/calendar_pedidos.html
@@ -1,6 +1,17 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Calendario pedidos</h2>
+<form id="quick-card-form" class="quick-card-form">
+  <label class="quick-card-field" for="quick-card-date">
+    <span>Fecha</span>
+    <input type="date" id="quick-card-date" name="date" required>
+  </label>
+  <label class="quick-card-field" for="quick-card-title">
+    <span>Título</span>
+    <input type="text" id="quick-card-title" name="title" placeholder="Título del pedido" required>
+  </label>
+  <button type="submit">Crear tarjeta</button>
+</form>
 <input type="text" id="filter-input" placeholder="Filtrar por título o cliente">
 <div class="pedidos-wrapper">
 <div class="pedidos-calendar-container">
@@ -258,6 +269,61 @@ document.addEventListener('DOMContentLoaded', () => {
   const initialFilterValue = pageParams.get('filter');
   const initialHighlightPid = pageParams.get('highlight');
   const START_DAY_HIGHLIGHT_CLASS = 'start-day-highlight';
+  const quickCardForm = document.getElementById('quick-card-form');
+  const quickCardDate = document.getElementById('quick-card-date');
+  const quickCardTitle = document.getElementById('quick-card-title');
+
+  function recalcCalendarHeights() {
+    const cells = document.querySelectorAll('.pedidos-calendar td:not(.week-label):not(.unconfirmed)');
+    if (!cells.length) return;
+    cells.forEach(cell => { cell.style.height = ''; });
+    let maxHeight = 0;
+    cells.forEach(cell => {
+      if (cell.offsetHeight > maxHeight) {
+        maxHeight = cell.offsetHeight;
+      }
+    });
+    cells.forEach(cell => { cell.style.height = maxHeight + 'px'; });
+  }
+
+  if (quickCardForm) {
+    quickCardForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const dateValue = quickCardDate ? quickCardDate.value : '';
+      const titleValue = quickCardTitle ? quickCardTitle.value.trim() : '';
+      if (!dateValue || !titleValue) {
+        return;
+      }
+      const targetCell = document.querySelector(`.pedidos-calendar td.day-cell[data-date="${dateValue}"]`);
+      if (!targetCell) {
+        alert('La fecha seleccionada no está visible en el calendario.');
+        return;
+      }
+      const newTask = document.createElement('div');
+      newTask.className = 'task quick-card';
+      newTask.setAttribute('draggable', 'true');
+      newTask.dataset.project = titleValue;
+      newTask.dataset.title = titleValue;
+      newTask.dataset.client = '';
+      newTask.dataset.code = '';
+      newTask.dataset.day = dateValue;
+      newTask.dataset.due = dateValue;
+      const main = document.createElement('span');
+      main.className = 'task-main';
+      main.textContent = titleValue;
+      newTask.appendChild(main);
+      targetCell.appendChild(newTask);
+      recalcCalendarHeights();
+      const filterField = document.getElementById('filter-input');
+      if (filterField && filterField.value) {
+        filterField.dispatchEvent(new Event('input'));
+      }
+      if (quickCardForm) {
+        quickCardForm.reset();
+      }
+      newTask.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' });
+    });
+  }
 
   function parseSortableCell(cell) {
     if (!cell) {
@@ -1282,10 +1348,7 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     }
   }
-  const cells = document.querySelectorAll('.pedidos-calendar td:not(.week-label):not(.unconfirmed)');
-  let maxH = 0;
-  cells.forEach(c => { if (c.offsetHeight > maxH) maxH = c.offsetHeight; });
-  cells.forEach(c => c.style.height = maxH + 'px');
+  recalcCalendarHeights();
 
   let dragged = null;
   const tasks = document.querySelectorAll('.pedidos-calendar .task');

--- a/templates/complete.html
+++ b/templates/complete.html
@@ -572,6 +572,64 @@
   const historyList = document.getElementById('history-list');
   const historyClose = historyModal ? historyModal.querySelector('.history-close') : null;
   const historyTitle = document.getElementById('history-title');
+  let detachHistoryViewport = null;
+  let historyPositionFrame = null;
+
+  function centerHistoryModalNow() {
+    if (!historyModal || !historyModal.classList.contains('open')) return;
+    const content = historyModal.querySelector('.history-content');
+    if (!content) return;
+    const viewport = window.visualViewport || null;
+    let viewportWidth = window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth || 0;
+    let viewportHeight = window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight || 0;
+    let offsetLeft = 0;
+    let offsetTop = 0;
+    if (viewport) {
+      viewportWidth = viewport.width;
+      viewportHeight = viewport.height;
+      offsetLeft = viewport.offsetLeft || viewport.pageLeft || viewport.left || 0;
+      offsetTop = viewport.offsetTop || viewport.pageTop || viewport.top || 0;
+    }
+    const contentWidth = content.offsetWidth;
+    const contentHeight = content.offsetHeight;
+    const safePadding = 16;
+    const targetLeft = offsetLeft + Math.max((viewportWidth - contentWidth) / 2, safePadding);
+    const targetTop = offsetTop + Math.max((viewportHeight - contentHeight) / 2, safePadding);
+    content.style.position = 'fixed';
+    content.style.left = `${Math.round(targetLeft)}px`;
+    content.style.top = `${Math.round(targetTop)}px`;
+  }
+
+  function scheduleHistoryModalCenter() {
+    if (!historyModal || !historyModal.classList.contains('open')) return;
+    if (historyPositionFrame !== null) return;
+    historyPositionFrame = requestAnimationFrame(() => {
+      historyPositionFrame = null;
+      centerHistoryModalNow();
+    });
+  }
+
+  function bindHistoryViewportTracking() {
+    if (!historyModal || detachHistoryViewport) return;
+    const viewport = window.visualViewport || null;
+    const handler = () => scheduleHistoryModalCenter();
+    window.addEventListener('resize', handler);
+    window.addEventListener('scroll', handler, { passive: true });
+    if (viewport) {
+      viewport.addEventListener('resize', handler);
+      viewport.addEventListener('scroll', handler);
+    }
+    detachHistoryViewport = () => {
+      window.removeEventListener('resize', handler);
+      window.removeEventListener('scroll', handler);
+      if (viewport) {
+        viewport.removeEventListener('resize', handler);
+        viewport.removeEventListener('scroll', handler);
+      }
+      detachHistoryViewport = null;
+    };
+  }
+
   const dayMenuModal = document.getElementById('day-menu-modal');
   const dayMenuClose = dayMenuModal ? dayMenuModal.querySelector('.day-menu-close') : null;
   const dayMenuTitle = document.getElementById('day-menu-title');
@@ -810,8 +868,20 @@
   }
 
   function closeHistoryModal() {
-    if (historyModal) {
-      historyModal.classList.remove('open');
+    if (!historyModal) return;
+    historyModal.classList.remove('open');
+    if (historyPositionFrame !== null) {
+      cancelAnimationFrame(historyPositionFrame);
+      historyPositionFrame = null;
+    }
+    if (detachHistoryViewport) {
+      detachHistoryViewport();
+    }
+    const content = historyModal.querySelector('.history-content');
+    if (content) {
+      content.style.left = '';
+      content.style.top = '';
+      content.style.position = '';
     }
   }
 
@@ -819,6 +889,7 @@
     if (!historyList) return;
     if (!Array.isArray(entries) || !entries.length) {
       historyList.innerHTML = '<div class="history-empty">No hay movimientos registrados.</div>';
+      scheduleHistoryModalCenter();
       return;
     }
     const html = entries
@@ -837,6 +908,7 @@
       })
       .join('');
     historyList.innerHTML = html;
+    scheduleHistoryModalCenter();
   }
 
   function openHistory(pid, phase, part, projectName, clientName) {
@@ -851,7 +923,9 @@
       historyTitle.textContent = `Historial - ${baseTitle}${suffix}`;
     }
     historyModal.classList.add('open');
+    bindHistoryViewportTracking();
     historyList.innerHTML = '<div class="history-loading">Cargando...</div>';
+    scheduleHistoryModalCenter();
     const params = new URLSearchParams({ pid, phase });
     if (part) params.append('part', part);
     fetch(`${HISTORY_URL}?${params.toString()}`, {
@@ -862,11 +936,13 @@
       .then(data => {
         const entries = Array.isArray(data.history) ? data.history : [];
         renderHistoryEntries(entries);
+        scheduleHistoryModalCenter();
       })
       .catch(() => {
         if (historyList) {
           historyList.innerHTML = '<div class="history-error">No se pudo cargar el historial.</div>';
         }
+        scheduleHistoryModalCenter();
       });
   }
 

--- a/templates/complete.html
+++ b/templates/complete.html
@@ -1346,6 +1346,60 @@
     e.preventDefault();
     wrapper.scrollLeft += e.deltaY;
   });
+
+  let isDragScrolling = false;
+  let dragStartX = 0;
+  let dragStartScroll = 0;
+  let dragWithRightButton = false;
+  let suppressContextMenu = false;
+
+  function stopDragScroll() {
+    if (!isDragScrolling && !suppressContextMenu) return;
+    isDragScrolling = false;
+    if (suppressContextMenu) {
+      setTimeout(() => { suppressContextMenu = false; }, 0);
+    }
+    dragWithRightButton = false;
+    wrapper.classList.remove('dragging');
+  }
+
+  wrapper.addEventListener('mousedown', (e) => {
+    const wantsShiftDrag = e.button === 0 && e.shiftKey;
+    const wantsRightDrag = e.button === 2;
+    if (!wantsShiftDrag && !wantsRightDrag) return;
+    dragStartX = e.clientX;
+    dragStartScroll = wrapper.scrollLeft;
+    isDragScrolling = true;
+    dragWithRightButton = wantsRightDrag;
+    suppressContextMenu = wantsRightDrag;
+    wrapper.classList.add('dragging');
+    e.preventDefault();
+  });
+
+  window.addEventListener('mousemove', (e) => {
+    if (!isDragScrolling) return;
+    const requiredButton = dragWithRightButton ? 2 : 1;
+    if ((e.buttons & requiredButton) === 0) {
+      stopDragScroll();
+      return;
+    }
+    const delta = e.clientX - dragStartX;
+    wrapper.scrollLeft = dragStartScroll - delta;
+  });
+
+  window.addEventListener('mouseup', (e) => {
+    if (!isDragScrolling) return;
+    if (e.button !== 0 && e.button !== 2) return;
+    stopDragScroll();
+  });
+
+  window.addEventListener('blur', stopDragScroll);
+
+  wrapper.addEventListener('contextmenu', (e) => {
+    if (suppressContextMenu || isDragScrolling) {
+      e.preventDefault();
+    }
+  });
   const todayBtn = document.getElementById('today-btn');
   if (todayBtn) {
     todayBtn.addEventListener('click', () => {

--- a/templates/complete.html
+++ b/templates/complete.html
@@ -944,6 +944,14 @@
         return;
       }
       ev.preventDefault();
+      if (skipNextDayMenu) {
+        skipNextDayMenu = false;
+        if (skipDayMenuReset) {
+          clearTimeout(skipDayMenuReset);
+          skipDayMenuReset = null;
+        }
+        return;
+      }
       openDayMenu(row.dataset.worker, cell.dataset.date);
     });
   });
@@ -1352,14 +1360,28 @@
   let dragStartScroll = 0;
   let dragWithRightButton = false;
   let suppressContextMenu = false;
+  let dragMoved = false;
+  let skipNextDayMenu = false;
+  let skipDayMenuReset = null;
 
   function stopDragScroll() {
     if (!isDragScrolling && !suppressContextMenu) return;
+    if (dragWithRightButton && dragMoved) {
+      skipNextDayMenu = true;
+      if (skipDayMenuReset) {
+        clearTimeout(skipDayMenuReset);
+      }
+      skipDayMenuReset = setTimeout(() => {
+        skipNextDayMenu = false;
+        skipDayMenuReset = null;
+      }, 200);
+    }
     isDragScrolling = false;
     if (suppressContextMenu) {
       setTimeout(() => { suppressContextMenu = false; }, 0);
     }
     dragWithRightButton = false;
+    dragMoved = false;
     wrapper.classList.remove('dragging');
   }
 
@@ -1372,6 +1394,12 @@
     isDragScrolling = true;
     dragWithRightButton = wantsRightDrag;
     suppressContextMenu = wantsRightDrag;
+    dragMoved = false;
+    if (wantsRightDrag && skipDayMenuReset) {
+      clearTimeout(skipDayMenuReset);
+      skipDayMenuReset = null;
+      skipNextDayMenu = false;
+    }
     wrapper.classList.add('dragging');
     e.preventDefault();
   });
@@ -1384,6 +1412,9 @@
       return;
     }
     const delta = e.clientX - dragStartX;
+    if (!dragMoved && Math.abs(delta) > 2) {
+      dragMoved = true;
+    }
     wrapper.scrollLeft = dragStartScroll - delta;
   });
 
@@ -1396,8 +1427,9 @@
   window.addEventListener('blur', stopDragScroll);
 
   wrapper.addEventListener('contextmenu', (e) => {
+    e.preventDefault();
     if (suppressContextMenu || isDragScrolling) {
-      e.preventDefault();
+      return;
     }
   });
   const todayBtn = document.getElementById('today-btn');

--- a/templates/complete.html
+++ b/templates/complete.html
@@ -396,42 +396,43 @@
             <tbody>
             {% for p in projects %}
             <tr data-pid="{{ p.id }}" class="{% if p.frozen_tasks %}frozen{% endif %}">
-                <td>{{ p.name }}</td>
-                <td>{{ p.client }}</td>
-                <td>{{ p.due_date }}</td>
+                <td data-sort="{{ p.name|default('', true)|lower }}">{{ p.name }}</td>
+                <td data-sort="{{ p.client|default('', true)|lower }}">{{ p.client }}</td>
+                <td data-sort="{{ p.due_date or '' }}" data-sort-type="date">{{ p.due_date }}</td>
                 {% set pid_key = p.id|string if p.id is not none else p.id %}
                 {% set info = project_data.get(pid_key) %}
                 {% set status = p.material_status if p.material_status is defined and p.material_status else (info.material_status if info else 'complete') %}
                 {% set status_label = material_status_labels.get(status, status|capitalize) %}
-                <td>
+                <td data-sort="{{ status_label|lower }}">
                     <span class="material-status-flag material-status-{{ status }}">{{ status_label }}</span>
                 </td>
                 {% for ph in phases if ph not in ['dibujo', 'pedidos'] %}
-                    <td>
                     {% set val = p.phases.get(ph, 0) %}
                     {% if val is sequence %}
-                        {{ val|map('int')|sum }}h<br>
+                        {% set total = val|map('int')|sum %}
                     {% else %}
-                        {{ val|int }}h<br>
+                        {% set total = val|int %}
                     {% endif %}
+                    <td data-sort="{{ total }}" data-sort-type="number">
+                    {{ total }}h<br>
                         {% set assigned = p.assigned.get(ph) if p.assigned and p.assigned.get(ph) else 'Sin planificar' %}
                         <span>{{ assigned }}</span>
                         <form class="phase-hours-form" method="post" action="{{ url_for('update_phase_hours') }}">
                             <input type="hidden" name="pid" value="{{ p.id }}">
                             <input type="hidden" name="phase" value="{{ ph }}">
                             <input type="hidden" name="next" value="{{ url_for('complete') }}">
-                            <input type="number" name="hours" value="{{ val|map('int')|sum if val is sequence else (val|int) }}" min="1">
+                            <input type="number" name="hours" value="{{ total }}" min="1">
                         </form>
                         <span>{{ start_map.get(p.id, {}).get(ph, '') }}</span>
                     </td>
                 {% endfor %}
-                <td><button class="row-update-btn">ACTUALIZAR</button></td>
-                <td>
+                <td data-sort="0"><button class="row-update-btn">ACTUALIZAR</button></td>
+                <td data-sort="0">
                     <form method="post" action="{{ url_for('delete_project', pid=p.id, next=url_for('complete')) }}" class="delete-form">
                         <button class="delete-btn" type="submit">&#10060;</button>
                     </form>
                 </td>
-                <td>
+                <td data-sort="{{ 1 if p.image else 0 }}" data-sort-type="number">
                     {% if p.image %}
                         {{ p.image.rsplit('/', 1)[-1] }}
                     {% else %}
@@ -458,6 +459,88 @@
   const PROJ_START_URL = "{{ url_for('update_start_date') }}";
   const SPLIT_URL = "{{ url_for('split_phase_route') }}";
   const UNSPLIT_URL = "{{ url_for('unsplit_phase') }}";
+
+  function initProjectTableSorting(root = document) {
+    const collator = new Intl.Collator('es', { sensitivity: 'base', numeric: true });
+    root.querySelectorAll('.projects-table').forEach((table) => {
+      const tbody = table.tBodies[0];
+      if (!tbody) return;
+      const headers = table.querySelectorAll('thead th');
+      headers.forEach((th, index) => {
+        th.classList.add('sortable');
+        th.addEventListener('click', () => {
+          const order = th.dataset.sortOrder === 'asc' ? 'desc' : 'asc';
+          headers.forEach((other) => {
+            if (other !== th) {
+              other.dataset.sortOrder = '';
+              other.classList.remove('sorted-asc', 'sorted-desc');
+            }
+          });
+          th.dataset.sortOrder = order;
+          th.classList.toggle('sorted-asc', order === 'asc');
+          th.classList.toggle('sorted-desc', order === 'desc');
+          const rows = Array.from(tbody.querySelectorAll('tr'));
+          const parseCellValue = (cell) => {
+            if (!cell) {
+              return { blank: true, value: '', type: 'text' };
+            }
+            const raw = cell.dataset.sort !== undefined ? cell.dataset.sort : cell.textContent.trim();
+            const type = cell.dataset.sortType || 'text';
+            const rawString = raw === undefined || raw === null ? '' : `${raw}`;
+            const isBlank = rawString.trim() === '';
+            if (type === 'number') {
+              const num = Number(rawString);
+              return { blank: isBlank, value: Number.isNaN(num) ? 0 : num, type };
+            }
+            if (type === 'date') {
+              if (isBlank) {
+                return { blank: true, value: 0, type };
+              }
+              let time = Number.NaN;
+              if (/^\d{4}-\d{2}-\d{2}$/.test(rawString)) {
+                time = Date.parse(rawString);
+              } else if (/^\d{1,2}\/\d{1,2}\/\d{4}$/.test(rawString)) {
+                const [day, month, year] = rawString.split('/').map(Number);
+                if (!Number.isNaN(day) && !Number.isNaN(month) && !Number.isNaN(year)) {
+                  time = Date.UTC(year, month - 1, day);
+                }
+              } else {
+                time = Date.parse(rawString);
+              }
+              if (Number.isNaN(time)) {
+                return { blank: true, value: 0, type };
+              }
+              return { blank: false, value: time, type };
+            }
+            return { blank: isBlank, value: rawString.toLowerCase(), type: 'text' };
+          };
+          rows.sort((a, b) => {
+            const aCell = a.children[index];
+            const bCell = b.children[index];
+            const aVal = parseCellValue(aCell);
+            const bVal = parseCellValue(bCell);
+            if (aVal.blank && bVal.blank) return 0;
+            if (aVal.blank !== bVal.blank) {
+              return aVal.blank ? 1 : -1;
+            }
+            let comparison = 0;
+            if (aVal.type === 'number' && bVal.type === 'number') {
+              comparison = aVal.value - bVal.value;
+            } else if (aVal.type === 'date' && bVal.type === 'date') {
+              comparison = aVal.value - bVal.value;
+            } else {
+              comparison = collator.compare(aVal.value, bVal.value);
+            }
+            if (comparison === 0) return 0;
+            return order === 'asc' ? (comparison < 0 ? -1 : 1) : (comparison < 0 ? 1 : -1);
+          });
+          rows.forEach((row) => tbody.appendChild(row));
+        });
+      });
+    });
+  }
+
+  initProjectTableSorting();
   const REMOVE_ARCHIVED_URL = "{{ url_for('remove_archived_phase') }}";
   const HOURS_URL = "{{ url_for('update_hours') }}";
   const PHASE_HOURS_URL = "{{ url_for('update_phase_hours') }}";

--- a/templates/complete.html
+++ b/templates/complete.html
@@ -530,6 +530,67 @@
   const SPLIT_WORKDAY_HOURS = 8;
   const SPLIT_ORDINAL_WORDS = ['primera', 'segunda', 'tercera', 'cuarta', 'quinta', 'sexta', 'séptima', 'octava', 'novena', 'décima'];
 
+  const NO_BORDER_WORKERS = new Set(['Mecanizar', 'Tratamiento']);
+  const NO_BORDER_PHASES = new Set(['vacaciones', 'mecanizar', 'tratamiento']);
+
+  function getWorkerDayLimit(worker, dateText) {
+    if (WORKER_DAY_HOURS && WORKER_DAY_HOURS[worker] && WORKER_DAY_HOURS[worker][dateText] !== undefined) {
+      const parsed = Number(WORKER_DAY_HOURS[worker][dateText]);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+    if (DAILY_HOURS && DAILY_HOURS[dateText] !== undefined) {
+      const parsed = Number(DAILY_HOURS[dateText]);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+    return 8;
+  }
+
+  function findWorkerRow(worker) {
+    if (!worker) return null;
+    return Array.from(document.querySelectorAll('tr[data-worker]')).find(row => row.dataset.worker === worker) || null;
+  }
+
+  function findWorkerDayCell(worker, dateText) {
+    if (!worker || !dateText) return null;
+    const row = findWorkerRow(worker);
+    if (!row) return null;
+    return Array.from(row.querySelectorAll('td[data-date]')).find(td => td.dataset.date === dateText) || null;
+  }
+
+  function recomputeWorkerDayCell(worker, dateText) {
+    const cell = findWorkerDayCell(worker, dateText);
+    if (!cell) return;
+    const tasks = Array.from(cell.querySelectorAll('.task'));
+    let total = 0;
+    let hasNoBorderPhase = NO_BORDER_WORKERS.has(worker);
+    tasks.forEach(task => {
+      const phase = (task.dataset.phase || '').toLowerCase();
+      if (NO_BORDER_PHASES.has(phase)) {
+        hasNoBorderPhase = true;
+      }
+      const hoursVal = Number(task.dataset.hours);
+      if (Number.isFinite(hoursVal)) {
+        total += hoursVal;
+      }
+    });
+    const limit = getWorkerDayLimit(worker, dateText);
+    if (hasNoBorderPhase) {
+      cell.classList.add('vacation-day');
+      cell.classList.remove('incomplete');
+      return;
+    }
+    cell.classList.remove('vacation-day');
+    if (total < limit) {
+      cell.classList.add('incomplete');
+    } else {
+      cell.classList.remove('incomplete');
+    }
+  }
+
   function clampDayHours(value) {
     const num = Number(value);
     if (!Number.isFinite(num)) return 8;
@@ -1543,10 +1604,21 @@ let draggedTaskElement = null;
               }
               const targetPid = removeArchivedBtn.dataset.pid;
               const targetPhase = removeArchivedBtn.dataset.phase;
+              const affectedCells = new Set();
               document.querySelectorAll('.task').forEach(taskEl => {
                 if (taskEl.dataset.pid === targetPid && taskEl.dataset.phase === targetPhase && taskEl.dataset.archived === 'true') {
+                  const row = taskEl.closest('tr[data-worker]');
+                  const worker = row ? row.dataset.worker : null;
+                  const date = taskEl.dataset.day || null;
                   taskEl.remove();
+                  if (worker && date) {
+                    affectedCells.add(`${worker}|||${date}`);
+                  }
                 }
+              });
+              affectedCells.forEach(key => {
+                const [worker, date] = key.split('|||');
+                recomputeWorkerDayCell(worker, date);
               });
               const projectInfo = PROJECT_DATA[targetPid];
               if (projectInfo && typeof projectInfo === 'object') {
@@ -1564,6 +1636,9 @@ let draggedTaskElement = null;
                 }
                 if (Array.isArray(projectInfo.frozen_tasks)) {
                   projectInfo.frozen_tasks = projectInfo.frozen_tasks.filter(item => item && item.phase !== targetPhase);
+                }
+                if (Array.isArray(projectInfo.frozen_phases)) {
+                  projectInfo.frozen_phases = projectInfo.frozen_phases.filter(ph => ph !== targetPhase);
                 }
               }
               popup.style.display = 'none';

--- a/templates/complete.html
+++ b/templates/complete.html
@@ -383,11 +383,8 @@
             <tr>
                 <th>Nombre</th>
                 <th>Cliente</th>
-                <th>Fecha inicio</th>
                 <th>Fecha límite</th>
-                <th>Fecha material confirmado</th>
-                <th>En plazo</th>
-                <th>Planificado</th>
+                <th>Estado material</th>
                 {% for ph in phases if ph not in ['dibujo', 'pedidos'] %}
                     <th>{{ ph }}</th>
                 {% endfor %}
@@ -398,34 +395,16 @@
             </thead>
             <tbody>
             {% for p in projects %}
-            <tr data-pid="{{ p.id }}" class="{% if p.frozen_tasks %}frozen{% endif %}" style="background-color: {{ p.color }};">
+            <tr data-pid="{{ p.id }}" class="{% if p.frozen_tasks %}frozen{% endif %}">
                 <td>{{ p.name }}</td>
                 <td>{{ p.client }}</td>
-                <td>
-                    {{ p.start_date }}
-                    <form class="proj-start-form" method="post" action="{{ url_for('update_start_date') }}">
-                        <input type="hidden" name="pid" value="{{ p.id }}">
-                        <input type="hidden" name="next" value="{{ url_for('complete') }}">
-                        <input type="date" name="start_date" value="{{ p.start_date }}">
-                    </form>
-                </td>
                 <td>{{ p.due_date }}</td>
-                <td>{{ p.material_confirmed_date }}</td>
+                {% set pid_key = p.id|string if p.id is not none else p.id %}
+                {% set info = project_data.get(pid_key) %}
+                {% set status = p.material_status if p.material_status is defined and p.material_status else (info.material_status if info else 'complete') %}
+                {% set status_label = material_status_labels.get(status, status|capitalize) %}
                 <td>
-                    {% if p.met %}
-                        <span class="ok">&#10004;</span>
-                    {% else %}
-                        <span class="late">&#10060;</span>
-                    {% endif %}
-                </td>
-                <td class="plan-col">
-                    {% if p.plan_state == 'all' %}
-                        <span class="ok">&#9679;</span>
-                    {% elif p.plan_state == 'partial' %}
-                        <span class="unplanned">&#9679;</span>
-                    {% else %}
-                        <span class="late">&#9679;</span>
-                    {% endif %}
+                    <span class="material-status-flag material-status-{{ status }}">{{ status_label }}</span>
                 </td>
                 {% for ph in phases if ph not in ['dibujo', 'pedidos'] %}
                     <td>

--- a/templates/complete.html
+++ b/templates/complete.html
@@ -1530,7 +1530,7 @@ let draggedTaskElement = null;
           const isActivePhase = ph === t.dataset.phase;
           const partSuffix = isActivePhase ? phasePartSuffix : '';
           let line = `<div class="${classes.join(' ')}">${ph}${partSuffix}: ${total}h`;
-          if (isActivePhase && !isArchivedShadow) {
+          if (isActivePhase) {
             const partValue = normalizedPart;
             const partAttr = partValue ? ` data-part="${partValue}"` : '';
             line += ` <form id="phase-hours-form" style="display:inline"><input type="number" id="phase-hours-input" value="${total}" min="1" required><button type="submit" id="phase-hours-btn" data-pid="${t.dataset.pid}" data-phase="${ph}"${partAttr}>Cambiar horas</button></form>`;
@@ -1600,7 +1600,7 @@ let draggedTaskElement = null;
           const safeObsValue = escapeHtml(`${info.observations}`);
           actionLines.push(`<div class="popup-section"><strong>Observaciones</strong><div>${safeObsValue}</div></div>`);
         }
-        actionLines.push('<div class="popup-section popup-readonly">Proyecto archivado en Kanbanize. Acciones deshabilitadas.</div>');
+        actionLines.push('<div class="popup-section popup-readonly">Proyecto archivado en Kanbanize. Acciones limitadas.</div>');
       }
       if (info.image) {
           const imgUrl = `${STATIC_URL}${info.image}`;

--- a/templates/index.html
+++ b/templates/index.html
@@ -380,6 +380,64 @@
   const historyList = document.getElementById('history-list');
   const historyClose = historyModal ? historyModal.querySelector('.history-close') : null;
   const historyTitle = document.getElementById('history-title');
+  let detachHistoryViewport = null;
+  let historyPositionFrame = null;
+
+  function centerHistoryModalNow() {
+    if (!historyModal || !historyModal.classList.contains('open')) return;
+    const content = historyModal.querySelector('.history-content');
+    if (!content) return;
+    const viewport = window.visualViewport || null;
+    let viewportWidth = window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth || 0;
+    let viewportHeight = window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight || 0;
+    let offsetLeft = 0;
+    let offsetTop = 0;
+    if (viewport) {
+      viewportWidth = viewport.width;
+      viewportHeight = viewport.height;
+      offsetLeft = viewport.offsetLeft || viewport.pageLeft || viewport.left || 0;
+      offsetTop = viewport.offsetTop || viewport.pageTop || viewport.top || 0;
+    }
+    const contentWidth = content.offsetWidth;
+    const contentHeight = content.offsetHeight;
+    const safePadding = 16;
+    const targetLeft = offsetLeft + Math.max((viewportWidth - contentWidth) / 2, safePadding);
+    const targetTop = offsetTop + Math.max((viewportHeight - contentHeight) / 2, safePadding);
+    content.style.position = 'fixed';
+    content.style.left = `${Math.round(targetLeft)}px`;
+    content.style.top = `${Math.round(targetTop)}px`;
+  }
+
+  function scheduleHistoryModalCenter() {
+    if (!historyModal || !historyModal.classList.contains('open')) return;
+    if (historyPositionFrame !== null) return;
+    historyPositionFrame = requestAnimationFrame(() => {
+      historyPositionFrame = null;
+      centerHistoryModalNow();
+    });
+  }
+
+  function bindHistoryViewportTracking() {
+    if (!historyModal || detachHistoryViewport) return;
+    const viewport = window.visualViewport || null;
+    const handler = () => scheduleHistoryModalCenter();
+    window.addEventListener('resize', handler);
+    window.addEventListener('scroll', handler, { passive: true });
+    if (viewport) {
+      viewport.addEventListener('resize', handler);
+      viewport.addEventListener('scroll', handler);
+    }
+    detachHistoryViewport = () => {
+      window.removeEventListener('resize', handler);
+      window.removeEventListener('scroll', handler);
+      if (viewport) {
+        viewport.removeEventListener('resize', handler);
+        viewport.removeEventListener('scroll', handler);
+      }
+      detachHistoryViewport = null;
+    };
+  }
+
   const dayMenuModal = document.getElementById('day-menu-modal');
   const dayMenuClose = dayMenuModal ? dayMenuModal.querySelector('.day-menu-close') : null;
   const dayMenuTitle = document.getElementById('day-menu-title');
@@ -614,8 +672,20 @@
   }
 
   function closeHistoryModal() {
-    if (historyModal) {
-      historyModal.classList.remove('open');
+    if (!historyModal) return;
+    historyModal.classList.remove('open');
+    if (historyPositionFrame !== null) {
+      cancelAnimationFrame(historyPositionFrame);
+      historyPositionFrame = null;
+    }
+    if (detachHistoryViewport) {
+      detachHistoryViewport();
+    }
+    const content = historyModal.querySelector('.history-content');
+    if (content) {
+      content.style.left = '';
+      content.style.top = '';
+      content.style.position = '';
     }
   }
 
@@ -623,6 +693,7 @@
     if (!historyList) return;
     if (!Array.isArray(entries) || !entries.length) {
       historyList.innerHTML = '<div class="history-empty">No hay movimientos registrados.</div>';
+      scheduleHistoryModalCenter();
       return;
     }
     const html = entries
@@ -641,6 +712,7 @@
       })
       .join('');
     historyList.innerHTML = html;
+    scheduleHistoryModalCenter();
   }
 
   function openHistory(pid, phase, part, projectName, clientName) {
@@ -655,7 +727,9 @@
       historyTitle.textContent = `Historial - ${baseTitle}${suffix}`;
     }
     historyModal.classList.add('open');
+    bindHistoryViewportTracking();
     historyList.innerHTML = '<div class="history-loading">Cargando...</div>';
+    scheduleHistoryModalCenter();
     const params = new URLSearchParams({ pid, phase });
     if (part) params.append('part', part);
     fetch(`${HISTORY_URL}?${params.toString()}`, {
@@ -666,11 +740,13 @@
       .then(data => {
         const entries = Array.isArray(data.history) ? data.history : [];
         renderHistoryEntries(entries);
+        scheduleHistoryModalCenter();
       })
       .catch(() => {
         if (historyList) {
           historyList.innerHTML = '<div class="history-error">No se pudo cargar el historial.</div>';
         }
+        scheduleHistoryModalCenter();
       });
   }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -352,6 +352,7 @@
   const START_URL = "{{ url_for('update_phase_start') }}";
   const SPLIT_URL = "{{ url_for('split_phase_route') }}";
   const UNSPLIT_URL = "{{ url_for('unsplit_phase') }}";
+  const REMOVE_ARCHIVED_URL = "{{ url_for('remove_archived_phase') }}";
   const HOURS_URL = "{{ url_for('update_hours') }}";
   const PHASE_HOURS_URL = "{{ url_for('update_phase_hours') }}";
   const WORKER_NOTE_URL = "{{ url_for('update_worker_note') }}";
@@ -395,6 +396,67 @@
         year: 'numeric',
       })
     : null;
+
+  const NO_BORDER_WORKERS = new Set(['Mecanizar', 'Tratamiento']);
+  const NO_BORDER_PHASES = new Set(['vacaciones', 'mecanizar', 'tratamiento']);
+
+  function getWorkerDayLimit(worker, dateText) {
+    if (WORKER_DAY_HOURS && WORKER_DAY_HOURS[worker] && WORKER_DAY_HOURS[worker][dateText] !== undefined) {
+      const parsed = Number(WORKER_DAY_HOURS[worker][dateText]);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+    if (DAILY_HOURS && DAILY_HOURS[dateText] !== undefined) {
+      const parsed = Number(DAILY_HOURS[dateText]);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+    return 8;
+  }
+
+  function findWorkerRow(worker) {
+    if (!worker) return null;
+    return Array.from(document.querySelectorAll('tr[data-worker]')).find(row => row.dataset.worker === worker) || null;
+  }
+
+  function findWorkerDayCell(worker, dateText) {
+    if (!worker || !dateText) return null;
+    const row = findWorkerRow(worker);
+    if (!row) return null;
+    return Array.from(row.querySelectorAll('td[data-date]')).find(td => td.dataset.date === dateText) || null;
+  }
+
+  function recomputeWorkerDayCell(worker, dateText) {
+    const cell = findWorkerDayCell(worker, dateText);
+    if (!cell) return;
+    const tasks = Array.from(cell.querySelectorAll('.task'));
+    let total = 0;
+    let hasNoBorderPhase = NO_BORDER_WORKERS.has(worker);
+    tasks.forEach(task => {
+      const phase = (task.dataset.phase || '').toLowerCase();
+      if (NO_BORDER_PHASES.has(phase)) {
+        hasNoBorderPhase = true;
+      }
+      const hoursVal = Number(task.dataset.hours);
+      if (Number.isFinite(hoursVal)) {
+        total += hoursVal;
+      }
+    });
+    const limit = getWorkerDayLimit(worker, dateText);
+    if (hasNoBorderPhase) {
+      cell.classList.add('vacation-day');
+      cell.classList.remove('incomplete');
+      return;
+    }
+    cell.classList.remove('vacation-day');
+    if (total < limit) {
+      cell.classList.add('incomplete');
+    } else {
+      cell.classList.remove('incomplete');
+    }
+  }
 
   function clampDayHours(value) {
     const num = Number(value);
@@ -1414,6 +1476,7 @@ let draggedTaskElement = null;
       let html = `<div class="popup-section popup-header"><strong>${displayName}${blockedBadge} - ${displayClient} - ${t.dataset.phase}${phasePartSuffix}</strong></div>`;
       const startMap = START_DATA[t.dataset.pid] || {};
       const startVal = startMap[t.dataset.phase] || '';
+      const kanbanColumn = ((info && info.kanban_column) || '').toString().trim().toLowerCase();
       const metaLines = [];
       const status = (info.material_status || '').toString();
       if (status === 'missing') {
@@ -1557,6 +1620,10 @@ let draggedTaskElement = null;
           </div>
         `);
       } else {
+        if (kanbanColumn === 'ready to archive') {
+          const archivePartAttr = normalizedPart ? ` data-part="${normalizedPart}"` : '';
+          actionLines.push(`<div><button type="button" class="remove-archived-phase-btn" data-pid="${t.dataset.pid}" data-phase="${t.dataset.phase}"${archivePartAttr}>Eliminar fase archivada</button></div>`);
+        }
         if (info && info.observations) {
           const safeObsValue = escapeHtml(`${info.observations}`);
           actionLines.push(`<div class="popup-section"><strong>Observaciones</strong><div>${safeObsValue}</div></div>`);
@@ -1606,6 +1673,69 @@ let draggedTaskElement = null;
           } catch (error) {
             console.error('No se pudo abrir Calendario pedidos:', error);
           }
+        });
+      }
+      const removeArchivedBtn = popup.querySelector('.remove-archived-phase-btn');
+      if (removeArchivedBtn) {
+        removeArchivedBtn.addEventListener('click', ev => {
+          ev.stopPropagation();
+          if (!confirm('¿Eliminar esta fase archivada del calendario?')) return;
+          const payload = { pid: removeArchivedBtn.dataset.pid, phase: removeArchivedBtn.dataset.phase };
+          fetch(REMOVE_ARCHIVED_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'same-origin',
+            body: JSON.stringify(payload)
+          })
+            .then(resp => resp.json().then(data => ({ ok: resp.ok, data })).catch(() => ({ ok: resp.ok, data: {} })))
+            .then(({ ok, data }) => {
+              if (!ok) {
+                throw new Error(data.error || 'Error eliminando fase archivada');
+              }
+              const targetPid = removeArchivedBtn.dataset.pid;
+              const targetPhase = removeArchivedBtn.dataset.phase;
+              const affectedCells = new Set();
+              document.querySelectorAll('.task').forEach(taskEl => {
+                if (taskEl.dataset.pid === targetPid && taskEl.dataset.phase === targetPhase && taskEl.dataset.archived === 'true') {
+                  const row = taskEl.closest('tr[data-worker]');
+                  const worker = row ? row.dataset.worker : null;
+                  const date = taskEl.dataset.day || null;
+                  taskEl.remove();
+                  if (worker && date) {
+                    affectedCells.add(`${worker}|||${date}`);
+                  }
+                }
+              });
+              affectedCells.forEach(key => {
+                const [worker, date] = key.split('|||');
+                recomputeWorkerDayCell(worker, date);
+              });
+              const projectInfo = PROJECT_DATA[targetPid];
+              if (projectInfo && typeof projectInfo === 'object') {
+                if (projectInfo.phases && Object.prototype.hasOwnProperty.call(projectInfo.phases, targetPhase)) {
+                  delete projectInfo.phases[targetPhase];
+                }
+                if (projectInfo.assigned && Object.prototype.hasOwnProperty.call(projectInfo.assigned, targetPhase)) {
+                  delete projectInfo.assigned[targetPhase];
+                }
+                if (projectInfo.auto_hours && Object.prototype.hasOwnProperty.call(projectInfo.auto_hours, targetPhase)) {
+                  delete projectInfo.auto_hours[targetPhase];
+                }
+                if (Array.isArray(projectInfo.phase_sequence)) {
+                  projectInfo.phase_sequence = projectInfo.phase_sequence.filter(item => item !== targetPhase);
+                }
+                if (Array.isArray(projectInfo.frozen_tasks)) {
+                  projectInfo.frozen_tasks = projectInfo.frozen_tasks.filter(item => item && item.phase !== targetPhase);
+                }
+                if (Array.isArray(projectInfo.frozen_phases)) {
+                  projectInfo.frozen_phases = projectInfo.frozen_phases.filter(ph => ph !== targetPhase);
+                }
+              }
+              popup.style.display = 'none';
+            })
+            .catch(err => {
+              alert(err.message || 'Error eliminando fase archivada');
+            });
         });
       }
       const del = document.getElementById('del-btn');

--- a/templates/index.html
+++ b/templates/index.html
@@ -748,6 +748,14 @@
         return;
       }
       ev.preventDefault();
+      if (skipNextDayMenu) {
+        skipNextDayMenu = false;
+        if (skipDayMenuReset) {
+          clearTimeout(skipDayMenuReset);
+          skipDayMenuReset = null;
+        }
+        return;
+      }
       openDayMenu(row.dataset.worker, cell.dataset.date);
     });
   });
@@ -1382,14 +1390,28 @@
   let dragStartScroll = 0;
   let dragWithRightButton = false;
   let suppressContextMenu = false;
+  let dragMoved = false;
+  let skipNextDayMenu = false;
+  let skipDayMenuReset = null;
 
   function stopDragScroll() {
     if (!isDragScrolling && !suppressContextMenu) return;
+    if (dragWithRightButton && dragMoved) {
+      skipNextDayMenu = true;
+      if (skipDayMenuReset) {
+        clearTimeout(skipDayMenuReset);
+      }
+      skipDayMenuReset = setTimeout(() => {
+        skipNextDayMenu = false;
+        skipDayMenuReset = null;
+      }, 200);
+    }
     isDragScrolling = false;
     if (suppressContextMenu) {
       setTimeout(() => { suppressContextMenu = false; }, 0);
     }
     dragWithRightButton = false;
+    dragMoved = false;
     wrapper.classList.remove('dragging');
   }
 
@@ -1402,6 +1424,12 @@
     isDragScrolling = true;
     dragWithRightButton = wantsRightDrag;
     suppressContextMenu = wantsRightDrag;
+    dragMoved = false;
+    if (wantsRightDrag && skipDayMenuReset) {
+      clearTimeout(skipDayMenuReset);
+      skipDayMenuReset = null;
+      skipNextDayMenu = false;
+    }
     wrapper.classList.add('dragging');
     e.preventDefault();
   });
@@ -1414,6 +1442,9 @@
       return;
     }
     const delta = e.clientX - dragStartX;
+    if (!dragMoved && Math.abs(delta) > 2) {
+      dragMoved = true;
+    }
     wrapper.scrollLeft = dragStartScroll - delta;
   });
 
@@ -1426,8 +1457,9 @@
   window.addEventListener('blur', stopDragScroll);
 
   wrapper.addEventListener('contextmenu', (e) => {
+    e.preventDefault();
     if (suppressContextMenu || isDragScrolling) {
-      e.preventDefault();
+      return;
     }
   });
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1377,6 +1377,60 @@
     wrapper.scrollLeft += e.deltaY;
   });
 
+  let isDragScrolling = false;
+  let dragStartX = 0;
+  let dragStartScroll = 0;
+  let dragWithRightButton = false;
+  let suppressContextMenu = false;
+
+  function stopDragScroll() {
+    if (!isDragScrolling && !suppressContextMenu) return;
+    isDragScrolling = false;
+    if (suppressContextMenu) {
+      setTimeout(() => { suppressContextMenu = false; }, 0);
+    }
+    dragWithRightButton = false;
+    wrapper.classList.remove('dragging');
+  }
+
+  wrapper.addEventListener('mousedown', (e) => {
+    const wantsShiftDrag = e.button === 0 && e.shiftKey;
+    const wantsRightDrag = e.button === 2;
+    if (!wantsShiftDrag && !wantsRightDrag) return;
+    dragStartX = e.clientX;
+    dragStartScroll = wrapper.scrollLeft;
+    isDragScrolling = true;
+    dragWithRightButton = wantsRightDrag;
+    suppressContextMenu = wantsRightDrag;
+    wrapper.classList.add('dragging');
+    e.preventDefault();
+  });
+
+  window.addEventListener('mousemove', (e) => {
+    if (!isDragScrolling) return;
+    const requiredButton = dragWithRightButton ? 2 : 1;
+    if ((e.buttons & requiredButton) === 0) {
+      stopDragScroll();
+      return;
+    }
+    const delta = e.clientX - dragStartX;
+    wrapper.scrollLeft = dragStartScroll - delta;
+  });
+
+  window.addEventListener('mouseup', (e) => {
+    if (!isDragScrolling) return;
+    if (e.button !== 0 && e.button !== 2) return;
+    stopDragScroll();
+  });
+
+  window.addEventListener('blur', stopDragScroll);
+
+  wrapper.addEventListener('contextmenu', (e) => {
+    if (suppressContextMenu || isDragScrolling) {
+      e.preventDefault();
+    }
+  });
+
   const todayBtn = document.getElementById('today-btn');
   if (todayBtn) {
     todayBtn.addEventListener('click', () => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -1559,7 +1559,7 @@ let draggedTaskElement = null;
           const isActivePhase = ph === t.dataset.phase;
           const partSuffix = isActivePhase ? phasePartSuffix : '';
           let line = `<div class="${classes.join(' ')}">${ph}${partSuffix}: ${total}h`;
-          if (isActivePhase && !isArchivedShadow) {
+          if (isActivePhase) {
             const partValue = normalizedPart;
             const partAttr = partValue ? ` data-part="${partValue}"` : '';
             line += ` <form id="phase-hours-form" style="display:inline"><input type="number" id="phase-hours-input" value="${total}" min="1" required><button type="submit" id="phase-hours-btn" data-pid="${t.dataset.pid}" data-phase="${ph}"${partAttr}>Cambiar horas</button></form>`;
@@ -1628,7 +1628,7 @@ let draggedTaskElement = null;
           const safeObsValue = escapeHtml(`${info.observations}`);
           actionLines.push(`<div class="popup-section"><strong>Observaciones</strong><div>${safeObsValue}</div></div>`);
         }
-        actionLines.push('<div class="popup-section popup-readonly">Proyecto archivado en Kanbanize. Acciones deshabilitadas.</div>');
+        actionLines.push('<div class="popup-section popup-readonly">Proyecto archivado en Kanbanize. Acciones limitadas.</div>');
       }
       if (info.image) {
         const imgUrl = `${STATIC_URL}${info.image}`;

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -17,11 +17,8 @@
     <tr>
         <th>Nombre</th>
         <th>Cliente</th>
-        <th>Fecha inicio</th>
         <th>Fecha límite</th>
-        <th>Fecha material confirmado</th>
-        <th>En plazo</th>
-        <th>Planificado</th>
+        <th>Estado material</th>
         {% for ph in phases if ph not in ['dibujo', 'pedidos'] %}
             <th>{{ ph }}</th>
         {% endfor %}
@@ -32,34 +29,14 @@
     </thead>
     <tbody>
     {% for p in projects %}
-    <tr data-pid="{{ p.id }}" class="{% if p.frozen_tasks %}frozen{% endif %}" style="background-color: {{ p.color }};">
+    <tr data-pid="{{ p.id }}" class="{% if p.frozen_tasks %}frozen{% endif %}">
         <td>{{ p.name }}{% if p.blocked %}<span class="blocked-sign">&#128683;</span>{% endif %}</td>
         <td>{{ p.client }}</td>
-        <td>
-            {{ p.start_date }}
-            <form class="proj-start-form" method="post" action="{{ url_for('update_start_date') }}">
-                <input type="hidden" name="pid" value="{{ p.id }}">
-                <input type="hidden" name="next" value="{{ url_for('project_list') }}">
-                <input type="date" name="start_date" value="{{ p.start_date }}">
-            </form>
-        </td>
         <td>{{ p.due_date }}</td>
-        <td>{{ p.material_confirmed_date }}</td>
+        {% set status = p.material_status if p.material_status is defined and p.material_status else 'complete' %}
+        {% set status_label = material_status_labels.get(status, status|capitalize) %}
         <td>
-            {% if p.met %}
-                <span class="ok">&#10004;</span>
-            {% else %}
-                <span class="late">&#10060;</span>
-            {% endif %}
-        </td>
-        <td class="plan-col">
-            {% if p.plan_state == 'all' %}
-                <span class="ok">&#9679;</span>
-            {% elif p.plan_state == 'partial' %}
-                <span class="unplanned">&#9679;</span>
-            {% else %}
-                <span class="late">&#9679;</span>
-            {% endif %}
+            <span class="material-status-flag material-status-{{ status }}">{{ status_label }}</span>
         </td>
         {% for ph in phases if ph not in ['dibujo', 'pedidos'] %}
             <td>

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -30,43 +30,42 @@
     <tbody>
     {% for p in projects %}
     <tr data-pid="{{ p.id }}" class="{% if p.frozen_tasks %}frozen{% endif %}">
-        <td>{{ p.name }}{% if p.blocked %}<span class="blocked-sign">&#128683;</span>{% endif %}</td>
-        <td>{{ p.client }}</td>
-        <td>{{ p.due_date }}</td>
+        <td data-sort="{{ p.name|default('', true)|lower }}">{{ p.name }}{% if p.blocked %}<span class="blocked-sign">&#128683;</span>{% endif %}</td>
+        <td data-sort="{{ p.client|default('', true)|lower }}">{{ p.client }}</td>
+        <td data-sort="{{ p.due_date or '' }}" data-sort-type="date">{{ p.due_date }}</td>
         {% set status = p.material_status if p.material_status is defined and p.material_status else 'complete' %}
         {% set status_label = material_status_labels.get(status, status|capitalize) %}
-        <td>
+        <td data-sort="{{ status_label|lower }}">
             <span class="material-status-flag material-status-{{ status }}">{{ status_label }}</span>
         </td>
         {% for ph in phases if ph not in ['dibujo', 'pedidos'] %}
-            <td>
             {% set val = p.phases.get(ph, 0) %}
-            {% set auto = p.auto_hours.get(ph) if p.auto_hours else False %}
             {% if val is sequence %}
                 {% set total = val|map('int')|sum %}
-                {% if auto %}<span class="auto-hour">{{ total }}h</span>{% else %}{{ total }}h{% endif %}<br>
             {% else %}
                 {% set total = val|int %}
-                {% if auto %}<span class="auto-hour">{{ total }}h</span>{% else %}{{ total }}h{% endif %}<br>
             {% endif %}
+            <td data-sort="{{ total }}" data-sort-type="number">
+            {% set auto = p.auto_hours.get(ph) if p.auto_hours else False %}
+            {% if auto %}<span class="auto-hour">{{ total }}h</span>{% else %}{{ total }}h{% endif %}<br>
                 {% set assigned = p.assigned.get(ph) if p.assigned and p.assigned.get(ph) else 'Sin planificar' %}
                 <span>{{ assigned }}</span>
                 <form class="phase-hours-form" method="post" action="{{ url_for('update_phase_hours') }}">
                     <input type="hidden" name="pid" value="{{ p.id }}">
                     <input type="hidden" name="phase" value="{{ ph }}">
                     <input type="hidden" name="next" value="{{ url_for('project_list') }}">
-                    <input type="number" name="hours" value="{{ val|map('int')|sum if val is sequence else (val|int) }}" min="0">
+                    <input type="number" name="hours" value="{{ total }}" min="0">
                 </form>
                 <span>{{ start_map.get(p.id, {}).get(ph, '') }}</span>
             </td>
         {% endfor %}
-        <td><button class="row-update-btn">ACTUALIZAR</button></td>
-        <td>
+        <td data-sort="0"><button class="row-update-btn">ACTUALIZAR</button></td>
+        <td data-sort="0">
             <form method="post" action="{{ url_for('delete_project', pid=p.id, next=url_for('project_list')) }}" class="delete-form">
                 <button class="delete-btn" type="submit">&#10060;</button>
             </form>
         </td>
-        <td>
+        <td data-sort="{{ 1 if p.image else 0 }}" data-sort-type="number">
             {% if p.image %}
                 {{ p.image.rsplit('/', 1)[-1] }}
             {% else %}
@@ -85,6 +84,88 @@
   const PROJ_START_URL = "{{ url_for('update_start_date') }}";
   const PHASE_HOURS_URL = "{{ url_for('update_phase_hours') }}";
   const ROW_URL = "{{ url_for('update_project_row') }}";
+
+  function initProjectTableSorting(root = document) {
+    const collator = new Intl.Collator('es', { sensitivity: 'base', numeric: true });
+    root.querySelectorAll('.projects-table').forEach((table) => {
+      const tbody = table.tBodies[0];
+      if (!tbody) return;
+      const headers = table.querySelectorAll('thead th');
+      headers.forEach((th, index) => {
+        th.classList.add('sortable');
+        th.addEventListener('click', () => {
+          const order = th.dataset.sortOrder === 'asc' ? 'desc' : 'asc';
+          headers.forEach((other) => {
+            if (other !== th) {
+              other.dataset.sortOrder = '';
+              other.classList.remove('sorted-asc', 'sorted-desc');
+            }
+          });
+          th.dataset.sortOrder = order;
+          th.classList.toggle('sorted-asc', order === 'asc');
+          th.classList.toggle('sorted-desc', order === 'desc');
+          const rows = Array.from(tbody.querySelectorAll('tr'));
+          const parseCellValue = (cell) => {
+            if (!cell) {
+              return { blank: true, value: '', type: 'text' };
+            }
+            const raw = cell.dataset.sort !== undefined ? cell.dataset.sort : cell.textContent.trim();
+            const type = cell.dataset.sortType || 'text';
+            const rawString = raw === undefined || raw === null ? '' : `${raw}`;
+            const isBlank = rawString.trim() === '';
+            if (type === 'number') {
+              const num = Number(rawString);
+              return { blank: isBlank, value: Number.isNaN(num) ? 0 : num, type };
+            }
+            if (type === 'date') {
+              if (isBlank) {
+                return { blank: true, value: 0, type };
+              }
+              let time = Number.NaN;
+              if (/^\d{4}-\d{2}-\d{2}$/.test(rawString)) {
+                time = Date.parse(rawString);
+              } else if (/^\d{1,2}\/\d{1,2}\/\d{4}$/.test(rawString)) {
+                const [day, month, year] = rawString.split('/').map(Number);
+                if (!Number.isNaN(day) && !Number.isNaN(month) && !Number.isNaN(year)) {
+                  time = Date.UTC(year, month - 1, day);
+                }
+              } else {
+                time = Date.parse(rawString);
+              }
+              if (Number.isNaN(time)) {
+                return { blank: true, value: 0, type };
+              }
+              return { blank: false, value: time, type };
+            }
+            return { blank: isBlank, value: rawString.toLowerCase(), type: 'text' };
+          };
+          rows.sort((a, b) => {
+            const aCell = a.children[index];
+            const bCell = b.children[index];
+            const aVal = parseCellValue(aCell);
+            const bVal = parseCellValue(bCell);
+            if (aVal.blank && bVal.blank) return 0;
+            if (aVal.blank !== bVal.blank) {
+              return aVal.blank ? 1 : -1;
+            }
+            let comparison = 0;
+            if (aVal.type === 'number' && bVal.type === 'number') {
+              comparison = aVal.value - bVal.value;
+            } else if (aVal.type === 'date' && bVal.type === 'date') {
+              comparison = aVal.value - bVal.value;
+            } else {
+              comparison = collator.compare(aVal.value, bVal.value);
+            }
+            if (comparison === 0) return 0;
+            return order === 'asc' ? (comparison < 0 ? -1 : 1) : (comparison < 0 ? 1 : -1);
+          });
+          rows.forEach((row) => tbody.appendChild(row));
+        });
+      });
+    });
+  }
+
+  initProjectTableSorting();
   document.querySelectorAll('.proj-start-form').forEach(f => {
     f.addEventListener('submit', ev => {
       ev.preventDefault();


### PR DESCRIPTION
## Summary
- recalculate worker-day capacity after removing archived phases so freed hours show immediately
- update archived project data in-memory after removal and offer the removal action on the calendar view

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6908b3f9ebcc832593f288babf4fc538